### PR TITLE
docs: correct GitHub repository owner links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,12 +90,12 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
-[Unreleased]: https://github.com/baylarsadigov/omp-undo-redo/compare/v1.0.7...HEAD
-[1.0.7]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.7
-[1.0.6]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.6
-[1.0.5]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.5
-[1.0.4]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.4
-[1.0.3]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.3
-[1.0.2]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.2
-[1.0.1]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.1
-[1.0.0]: https://github.com/baylarsadigov/omp-undo-redo/releases/tag/v1.0.0
+[Unreleased]: https://github.com/Baylar55/omp-undo-redo/compare/v1.0.7...HEAD
+[1.0.7]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.7
+[1.0.6]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.6
+[1.0.5]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.5
+[1.0.4]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.4
+[1.0.3]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.3
+[1.0.2]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.2
+[1.0.1]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.1
+[1.0.0]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A release consists of a reviewed change, a clean verification run, an updated `C
 
 ## Security
 
-Please read [SECURITY.md](./SECURITY.md) before reporting a vulnerability. Do not disclose credentials or sensitive data in a public issue. For normal bugs and feature requests, use the [GitHub issue tracker](https://github.com/baylarsadigov/omp-undo-redo/issues).
+Please read [SECURITY.md](./SECURITY.md) before reporting a vulnerability. Do not disclose credentials or sensitive data in a public issue. For normal bugs and feature requests, use the [GitHub issue tracker](https://github.com/Baylar55/omp-undo-redo/issues).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest published version is supported. The extension is tested with OMP
 
 ## Reporting a vulnerability
 
-Please do not report security vulnerabilities in a public issue. Use the repository's GitHub security advisory/private reporting feature: <https://github.com/baylarsadigov/omp-undo-redo/security/advisories/new>.
+Please do not report security vulnerabilities in a public issue. Use the repository's GitHub security advisory/private reporting feature: <https://github.com/Baylar55/omp-undo-redo/security/advisories/new>.
 
 Include a concise description, affected version, reproduction steps, impact, and any proposed mitigation. Remove tokens, credentials, private session data, and unrelated personal information before sending a report. If the private channel is unavailable, open a minimal issue asking for a private contact without including vulnerability details.
 


### PR DESCRIPTION
Replace incorrect baylarsadigov GitHub URLs with the canonical Baylar55 repository owner. npm package scope references remain unchanged.