### PR TITLE
docs: link npm package and document OMP installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.15] - 2026-07-18
+
+### Changed
+
+- Added npm, repository, homepage, and issue-tracker links to package metadata and documentation.
+- Documented `omp plugin install` and `omp plugin upgrade` as the supported OMP installation and update commands.
+
 ## [1.0.14] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OMP Undo/Redo
 
+[![npm version](https://img.shields.io/npm/v/%40baylarsadigov%2Fomp-undo-redo)](https://www.npmjs.com/package/@baylarsadigov/omp-undo-redo)
+[![CI](https://github.com/Baylar55/omp-undo-redo/actions/workflows/ci.yml/badge.svg)](https://github.com/Baylar55/omp-undo-redo/actions/workflows/ci.yml)
+
+Official npm package: [@baylarsadigov/omp-undo-redo](https://www.npmjs.com/package/@baylarsadigov/omp-undo-redo)
+
 A small Oh My Pi (OMP) extension for moving through the current session's conversation tree. It adds two slash commands without changing OMP's files or session format.
 
 ## Requirements
@@ -9,11 +14,25 @@ A small Oh My Pi (OMP) extension for moving through the current session's conver
 
 ## Installation
 
-Install `@baylarsadigov/omp-undo-redo` from npm, then let OMP discover the extension through the package's plugin manifest. The published manifest contains:
+Install the extension through OMP's plugin manager. Running `npm install` in an arbitrary project only downloads the package; it does not register the extension with OMP:
 
 ```sh
-npm install @baylarsadigov/omp-undo-redo
+omp plugin install @baylarsadigov/omp-undo-redo
 ```
+
+To pin an exact release:
+
+```sh
+omp plugin install @baylarsadigov/omp-undo-redo@1.0.15
+```
+
+To update an existing installation, run the same command with the new version, or use:
+
+```sh
+omp plugin upgrade @baylarsadigov/omp-undo-redo
+```
+
+OMP discovers the compiled entry through the package manifest:
 
 ```json
 {
@@ -23,7 +42,7 @@ npm install @baylarsadigov/omp-undo-redo
 }
 ```
 
-Do not add a second entry for the extension when the package manifest is already being used. OMP loads the compiled entry through that manifest; no source checkout or undocumented OMP command is required.
+The `pi.extensions` manifest is also included for Pi-compatible loaders. Do not add a second extension entry when the package is installed through the plugin manager.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
+  "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Baylar55/omp-undo-redo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Baylar55/omp-undo-redo/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "engines": {


### PR DESCRIPTION
Add npm/repository metadata, npm and CI links, and document the supported omp plugin install and upgrade commands. Package release: 1.0.15.