### PR TITLE
Protect undo/redo checkpoints from Git garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## Unreleased
+
+### Fixed
+
+- Protect active undo/redo checkpoint commits with private refs so reflog expiry and aggressive Git garbage collection cannot invalidate navigation history.
+
 ## [1.0.16] - 2026-07-18
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Both commands wait for the current agent turn to become idle; if OMP remains bus
 
 ## Limitations
 
-Undo/redo uses temporary Git checkpoints around each turn, then mixed-resets the active branch back to its original `HEAD`. Restoring a checkpoint returns files to the exact before/after state while leaving the branch history unchanged and keeping local changes unstaged. It does not revert shell commands, network requests, editor state, or other external effects. Checkpoints are kept in memory and reset when OMP or the extension is reloaded. Navigation can also be cancelled by OMP lifecycle handlers.
+Undo/redo uses temporary Git checkpoints around each turn, then mixed-resets the active branch back to its original `HEAD`. The checkpoints are protected by private refs under `refs/omp-undo-redo/`, which keep active before/after commits safe from Git garbage collection without creating branches or tags. Releasing a checkpoint removes its refs when it leaves the active session history. Restoring a checkpoint returns files to the exact before/after state while leaving the branch history unchanged and keeping local changes unstaged. It does not revert shell commands, network requests, editor state, or other external effects. A forced process termination may leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed orphan refs with `git update-ref -d <ref> <expected-object-id>`. Do not change repository GC settings.
 
 ## Development
 

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -1,6 +1,28 @@
+import { createHash, randomUUID } from "node:crypto";
 import type { GitCheckpoint, GitRunner, SessionReader } from "./types.js";
 
 const GIT_AUTHOR = ["-c", "user.name=omp-undo-redo", "-c", "user.email=omp-undo-redo@local"];
+const REF_ROOT = "refs/omp-undo-redo";
+
+export function checkpointNamespace(sessionId: string): string {
+  return createHash("sha256").update(sessionId).digest("hex");
+}
+
+function checkpointRefs(
+  sessionId: string,
+  checkpointId: string,
+): { beforeRef: string; afterRef: string } {
+  const prefix = `${REF_ROOT}/${checkpointNamespace(sessionId)}/${checkpointId}`;
+  return { beforeRef: `${prefix}/before`, afterRef: `${prefix}/after` };
+}
+
+async function run(git: GitRunner, args: string[]): Promise<boolean> {
+  try {
+    return (await git(args)).code === 0;
+  } catch {
+    return false;
+  }
+}
 
 async function commitCheckpoint(git: GitRunner, message: string): Promise<string | null> {
   try {
@@ -9,39 +31,114 @@ async function commitCheckpoint(git: GitRunner, message: string): Promise<string
     const commit = await git([...GIT_AUTHOR, "commit", "--allow-empty", "-m", message]);
     if (commit.code !== 0) return null;
     const hash = await git(["rev-parse", "HEAD"]);
-    return hash.code === 0 ? hash.stdout.trim() : null;
+    const value = hash.stdout.trim();
+    return hash.code === 0 && value ? value : null;
   } catch {
     return null;
   }
+}
+
+async function releaseRef(git: GitRunner, ref: string, hash: string): Promise<boolean> {
+  return run(git, ["update-ref", "-d", ref, hash]);
+}
+
+export async function releaseCheckpoint(
+  git: GitRunner,
+  checkpoint: GitCheckpoint,
+): Promise<boolean> {
+  const before = await releaseRef(git, checkpoint.beforeRef, checkpoint.beforeHash);
+  const after = await releaseRef(git, checkpoint.afterRef, checkpoint.afterHash);
+  return before && after;
+}
+
+export async function releasePendingCheckpoint(
+  git: GitRunner,
+  pending: { beforeHash: string; beforeRef: string },
+): Promise<boolean> {
+  return releaseRef(git, pending.beforeRef, pending.beforeHash);
 }
 
 export async function prepareBeforeTurn(
   git: GitRunner,
-): Promise<{ baseHash: string; beforeHash: string } | null> {
+  sessionId: string,
+): Promise<{
+  baseHash: string;
+  beforeHash: string;
+  beforeRef: string;
+  checkpointId: string;
+} | null> {
+  let baseHash: string | null = null;
+  let beforeHash: string | null = null;
+  let beforeRef: string | null = null;
+  let protectedCheckpoint = false;
   try {
     const base = await git(["rev-parse", "HEAD"]);
-    if (base.code !== 0) return null;
-    const baseHash = base.stdout.trim();
-    const beforeHash = await commitCheckpoint(git, "omp-undo-redo: before turn");
+    if (base.code !== 0 || !(baseHash = base.stdout.trim())) return null;
+    const checkpointId = randomUUID();
+    beforeHash = await commitCheckpoint(git, "omp-undo-redo: before turn");
     if (!beforeHash) return null;
-    const reset = await git(["reset", baseHash]);
-    return reset.code === 0 ? { baseHash, beforeHash } : null;
-  } catch {
-    return null;
+    beforeRef = checkpointRefs(sessionId, checkpointId).beforeRef;
+    if (
+      !(await run(git, [
+        "update-ref",
+        "-m",
+        "omp-undo-redo: retain before checkpoint",
+        beforeRef,
+        beforeHash,
+      ]))
+    )
+      return null;
+    if (!(await run(git, ["reset", baseHash]))) return null;
+    protectedCheckpoint = true;
+    return { baseHash, beforeHash, beforeRef, checkpointId };
+  } finally {
+    if (baseHash && !protectedCheckpoint) {
+      await run(git, ["reset", baseHash]);
+      if (beforeHash && beforeRef) await releaseRef(git, beforeRef, beforeHash);
+    }
   }
 }
-
 export async function finishAfterTurn(
   git: GitRunner,
-  before: { baseHash: string; beforeHash: string },
+  before: { baseHash: string; beforeHash: string; beforeRef: string; checkpointId: string },
   parentLeafId: string | null,
   leafId: string | null,
 ): Promise<GitCheckpoint | null> {
-  const afterHash = await commitCheckpoint(git, "omp-undo-redo: after turn");
-  if (!afterHash) return null;
-  const reset = await git(["reset", before.baseHash]);
-  if (reset.code !== 0) return null;
-  return { ...before, afterHash, parentLeafId, leafId };
+  let afterHash: string | null = null;
+  let afterRef: string | null = null;
+  let protectedCheckpoint = false;
+  try {
+    afterHash = await commitCheckpoint(git, "omp-undo-redo: after turn");
+    if (!afterHash) return null;
+    afterRef = before.beforeRef.replace(/\/before$/, "/after");
+    if (
+      !(await run(git, [
+        "update-ref",
+        "-m",
+        "omp-undo-redo: retain after checkpoint",
+        afterRef,
+        afterHash,
+      ]))
+    )
+      return null;
+    if (!(await run(git, ["reset", before.baseHash]))) return null;
+    protectedCheckpoint = true;
+    return {
+      baseHash: before.baseHash,
+      beforeHash: before.beforeHash,
+      beforeRef: before.beforeRef,
+      afterHash,
+      afterRef,
+      parentLeafId,
+      leafId,
+    };
+  } finally {
+    await run(git, ["reset", before.baseHash]);
+    if (!protectedCheckpoint) {
+      await releaseRef(git, before.beforeRef, before.beforeHash);
+      if (afterHash && afterRef) await releaseRef(git, afterRef, afterHash);
+    }
+  }
 }
 
 export async function restoreCheckpoint(

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -1,5 +1,5 @@
 import type { GitCheckpoint, GitRunner, NavigationPort } from "./types.js";
-import { restoreCheckpoint } from "./checkpoints.js";
+import { releaseCheckpoint, restoreCheckpoint } from "./checkpoints.js";
 
 export type NavigationOutcome = "moved" | "empty" | "cancelled" | "git_failed";
 
@@ -21,12 +21,21 @@ export class SessionNavigation {
     this.navigateTree = navigateTree;
   }
 
-  recordTurnEnd(checkpoint: GitCheckpoint): void {
-    if (this.currentIndex < this.checkpoints.length - 1) {
-      this.checkpoints.splice(this.currentIndex + 1);
-    }
+  async recordTurnEnd(checkpoint: GitCheckpoint): Promise<void> {
+    const discarded = this.checkpoints.splice(
+      this.currentIndex + 1,
+      this.checkpoints.length - this.currentIndex - 1,
+    );
     this.checkpoints.push(checkpoint);
     this.currentIndex = this.checkpoints.length - 1;
+    await Promise.all(discarded.map((entry) => releaseCheckpoint(this.git, entry)));
+  }
+
+  async dispose(): Promise<void> {
+    const checkpoints = this.checkpoints;
+    this.checkpoints = [];
+    this.currentIndex = -1;
+    await Promise.all(checkpoints.map((entry) => releaseCheckpoint(this.git, entry)));
   }
 
   async undo(): Promise<NavigationOutcome> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,7 +22,9 @@ export interface NavigationPort extends SessionReader {
 export interface GitCheckpoint {
   baseHash: string;
   beforeHash: string;
+  beforeRef: string;
   afterHash: string;
+  afterRef: string;
   parentLeafId: string | null;
   leafId: string | null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@ import type { SessionEntryLike } from "./core/types.js";
 import { runRedo } from "./commands/redo.js";
 import { runUndo } from "./commands/undo.js";
 import { SessionNavigation } from "./core/session-navigation.js";
-import { finishAfterTurn, prepareBeforeTurn } from "./core/checkpoints.js";
+import {
+  finishAfterTurn,
+  prepareBeforeTurn,
+  releasePendingCheckpoint,
+} from "./core/checkpoints.js";
 import type { GitRunner } from "./core/types.js";
 
 type AnyContext = {
@@ -43,12 +47,26 @@ function createNavigation(pi: ExtensionAPI, ctx: AnyContext): SessionNavigation 
 const navigations = new Map<string, SessionNavigation>();
 const pending = new Map<
   string,
-  { baseHash: string; beforeHash: string; parentLeafId: string | null }
+  {
+    baseHash: string;
+    beforeHash: string;
+    beforeRef: string;
+    checkpointId: string;
+    parentLeafId: string | null;
+  }
 >();
 
 export default function ompUndoRedo(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     const sessionId = ctx.sessionManager.getSessionId();
+    const previous = navigations.get(sessionId);
+    if (previous) await previous.dispose();
+    const previousPending = pending.get(sessionId);
+    if (previousPending)
+      await releasePendingCheckpoint(
+        createGitRunner(pi, (ctx as unknown as AnyContext).cwd),
+        previousPending,
+      );
     navigations.set(sessionId, createNavigation(pi, ctx as unknown as AnyContext));
     pending.delete(sessionId);
   });
@@ -56,7 +74,12 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
     const typed = ctx as unknown as AnyContext;
     const sessionId = typed.sessionManager.getSessionId();
-    const before = await prepareBeforeTurn(createGitRunner(pi, typed.cwd));
+    const oldPending = pending.get(sessionId);
+    if (oldPending) {
+      await releasePendingCheckpoint(createGitRunner(pi, typed.cwd), oldPending);
+      pending.delete(sessionId);
+    }
+    const before = await prepareBeforeTurn(createGitRunner(pi, typed.cwd), sessionId);
     if (before) {
       pending.set(sessionId, {
         ...before,
@@ -70,17 +93,17 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     const sessionId = typed.sessionManager.getSessionId();
     const before = pending.get(sessionId);
     if (!before) return;
+    pending.delete(sessionId);
     const checkpoint = await finishAfterTurn(
       createGitRunner(pi, typed.cwd),
       before,
       before.parentLeafId,
       typed.sessionManager.getLeafId(),
     );
-    pending.delete(sessionId);
     if (!checkpoint) return;
     const nav = navigations.get(sessionId) ?? createNavigation(pi, typed);
     navigations.set(sessionId, nav);
-    nav.recordTurnEnd(checkpoint);
+    await nav.recordTurnEnd(checkpoint);
   });
 
   const undoHandler = async (_args: string, ctx: ExtensionCommandContext) => {

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -1,6 +1,20 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { previousCheckpoint } from "../src/core/checkpoints.js";
-import type { SessionEntryLike, SessionReader } from "../src/core/types.js";
+import {
+  checkpointNamespace,
+  finishAfterTurn,
+  prepareBeforeTurn,
+  previousCheckpoint,
+  releaseCheckpoint,
+  restoreCheckpoint,
+} from "../src/core/checkpoints.js";
+import type { GitRunner, SessionEntryLike, SessionReader } from "../src/core/types.js";
+
+const execFileAsync = promisify(execFile);
 
 function reader(entries: SessionEntryLike[], leafId: string | null): SessionReader {
   const byId = new Map(entries.map((entry) => [entry.id, entry]));
@@ -34,5 +48,80 @@ describe("previousCheckpoint", () => {
 
   it("selects the latest prompt boundary", () => {
     expect(previousCheckpoint(reader(entries, "a2"))).toBe("u2");
+  });
+});
+
+describe("checkpoint namespaces", () => {
+  it("hashes session IDs and keeps refs in the private namespace", () => {
+    const namespace = checkpointNamespace("session/raw id");
+    expect(namespace).toMatch(/^[0-9a-f]{64}$/);
+    expect(namespace).not.toContain("session");
+  });
+});
+
+describe("protected Git checkpoints", () => {
+  it("keeps active checkpoints reachable after reflog expiry and aggressive GC", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-"));
+    const git: GitRunner = async (args) => {
+      try {
+        const result = await execFileAsync("git", args, { cwd });
+        return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+      } catch (error) {
+        const failure = error as { stdout?: string; stderr?: string; code?: number };
+        return {
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? "",
+          code: failure.code ?? 1,
+        };
+      }
+    };
+    try {
+      await git(["init", "-q"]);
+      await git(["config", "user.name", "test"]);
+      await git(["config", "user.email", "test@example.com"]);
+      await git(["config", "core.autocrlf", "false"]);
+      await writeFile(join(cwd, "tracked.txt"), "base\n");
+      await git(["add", "."]);
+      await git(["commit", "-qm", "base"]);
+      await writeFile(join(cwd, "tracked.txt"), "before\n");
+      await writeFile(join(cwd, "deleted.txt"), "remove\n");
+      await git(["add", "."]);
+      await git(["commit", "-qm", "setup"]);
+      await git(["reset", "--mixed", "HEAD^"]);
+      await writeFile(join(cwd, "untracked.txt"), "before-only\n");
+
+      const before = await prepareBeforeTurn(git, "session/raw id");
+      expect(before).not.toBeNull();
+      if (!before) return;
+      await writeFile(join(cwd, "tracked.txt"), "after\n");
+      await writeFile(join(cwd, "untracked.txt"), "after-only\n");
+      const checkpoint = await finishAfterTurn(git, before, null, null);
+      expect(checkpoint).not.toBeNull();
+      if (!checkpoint) return;
+      expect((await git(["rev-parse", `${checkpoint.beforeRef}^{commit}`])).stdout.trim()).toBe(
+        checkpoint.beforeHash,
+      );
+      expect((await git(["rev-parse", `${checkpoint.afterRef}^{commit}`])).stdout.trim()).toBe(
+        checkpoint.afterHash,
+      );
+      await git(["reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"]);
+      await git(["gc", "--prune=now"]);
+      expect((await git(["cat-file", "-e", `${checkpoint.beforeHash}^{commit}`])).code).toBe(0);
+      expect((await git(["cat-file", "-e", `${checkpoint.afterHash}^{commit}`])).code).toBe(0);
+
+      expect(await restoreCheckpoint(git, checkpoint, checkpoint.beforeHash)).toBe(true);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("before\n");
+      expect(await readFile(join(cwd, "untracked.txt"), "utf8")).toBe("before-only\n");
+      expect(await restoreCheckpoint(git, checkpoint, checkpoint.afterHash)).toBe(true);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("after\n");
+      expect(await readFile(join(cwd, "untracked.txt"), "utf8")).toBe("after-only\n");
+      expect(await releaseCheckpoint(git, checkpoint)).toBe(true);
+      await git(["reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"]);
+      await git(["gc", "--prune=now"]);
+      expect((await git(["cat-file", "-e", `${checkpoint.beforeHash}^{commit}`])).code).not.toBe(0);
+      expect((await git(["cat-file", "-e", `${checkpoint.afterHash}^{commit}`])).code).not.toBe(0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/test/command-behavior.test.ts
+++ b/test/command-behavior.test.ts
@@ -55,7 +55,9 @@ function checkpoint(parentLeafId: string | null, leafId: string): GitCheckpoint 
   return {
     baseHash: "base",
     beforeHash: `before-${leafId}`,
+    beforeRef: `refs/omp-undo-redo/test/${leafId}/before`,
     afterHash: `after-${leafId}`,
+    afterRef: `refs/omp-undo-redo/test/${leafId}/after`,
     parentLeafId,
     leafId,
   };


### PR DESCRIPTION
Adds private refs for active checkpoint commits, failure-safe cleanup, async navigation disposal, and real-Git GC regression coverage.