### PR TITLE
release: publish v1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.20] - 2026-07-29
+
+### Fixed
+
+- Release active and pending private checkpoint refs during graceful `session_shutdown`, including checkpoints tracked by previously visited sessions and repositories.
+- Batch compare-and-delete private refs while preserving unrelated refs and leaving mismatched refs untouched.
+
 ## [1.0.19] - 2026-07-29
 
 ### Fixed
@@ -123,7 +130,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
-[Unreleased]: https://github.com/Baylar55/omp-undo-redo/compare/v1.0.19...HEAD
+[1.0.20]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.20
 [1.0.19]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.19
 [1.0.18]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.18
 [1.0.7]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.7

--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.0.16
-```
-
-To update an existing installation, run the same command with the new version, or use:
-
-```sh
-omp plugin upgrade @baylarsadigov/omp-undo-redo
+omp plugin install @baylarsadigov/omp-undo-redo@1.0.20
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -64,7 +58,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.0.16
+pi install npm:@baylarsadigov/omp-undo-redo@1.0.20
 ```
 
 To update installed Pi packages:
@@ -87,7 +81,7 @@ Both commands wait for the current agent turn to become idle; if OMP remains bus
 
 ## Limitations
 
-Undo/redo creates private Git snapshot objects through an alternate index and `git commit-tree`, then retains them with refs under `refs/omp-undo-redo/`. Checkpoint creation never moves `HEAD` or any branch ref. `/undo` and `/redo` apply file deltas only; they do not undo commits or branch switches. The real Git index is preserved, and releasing a checkpoint removes its private refs. A checkpoint covers the complete Git worktree that contains the session cwd; starting OMP from a repository subdirectory does not limit undo/redo to that subtree. Dirty files that existed before the turn are included in both snapshots and remain unchanged by undo/redo. Changes made anywhere in the repository during the turn can be part of the checkpoint because Git snapshots cannot determine authorship; this is an architectural limitation. The supported guarantee is: restores the non-ignored file changes represented by the checkpoint while preserving Git branch history and the real index. Ignored files, empty directories, dirty submodule contents, shell effects, network effects, and editor state are outside the checkpoint. Clean/smudge filters, `core.autocrlf`, submodules, and ignored files prevent a universal byte-for-byte guarantee. If overlapping worktree changes prevent safe application, undo/redo fails instead of overwriting them. A forced process termination may leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed stale refs.
+Undo/redo creates private Git snapshot objects through an alternate index and `git commit-tree`, then retains them with refs under `refs/omp-undo-redo/`. Checkpoint creation never moves `HEAD` or any branch ref. `/undo` and `/redo` apply file deltas only; they do not undo commits or branch switches. The real Git index is preserved, and releasing a checkpoint removes its private refs. A checkpoint covers the complete Git worktree that contains the session cwd; starting OMP from a repository subdirectory does not limit undo/redo to that subtree. Dirty files that existed before the turn are included in both snapshots and remain unchanged by undo/redo. Changes made anywhere in the repository during the turn can be part of the checkpoint because Git snapshots cannot determine authorship; this is an architectural limitation. The supported guarantee is: restores the non-ignored file changes represented by the checkpoint while preserving Git branch history and the real index. Ignored files, empty directories, dirty submodule contents, shell effects, network effects, and editor state are outside the checkpoint. Clean/smudge filters, `core.autocrlf`, submodules, and ignored files prevent a universal byte-for-byte guarantee. If overlapping worktree changes prevent safe application, undo/redo fails instead of overwriting them. Graceful session shutdown releases active and pending private refs. Forced termination, process kill, shutdown-handler timeout, or Git cleanup failure can still leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed stale refs. Do not delete refs from a repository while another OMP process may still be using them.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -91,24 +91,105 @@ async function createSnapshotCommit(git: GitRunner, message: string): Promise<st
   }
 }
 
-async function releaseRef(git: GitRunner, ref: string, hash: string): Promise<boolean> {
-  return run(git, ["update-ref", "-d", ref, hash]);
+export interface RefRelease {
+  repository: GitRepository;
+  ref: string;
+  expectedHash: string;
+}
+
+async function releaseRefBatch(
+  git: GitRunner,
+  refs: readonly Pick<RefRelease, "ref" | "expectedHash">[],
+): Promise<boolean> {
+  if (refs.length === 0) return true;
+  const input = refs.map(({ ref, expectedHash }) => `delete ${ref} ${expectedHash}`).join("\n");
+  try {
+    const result = await git(["update-ref", "--stdin"], { stdin: `${input}\n` });
+    if (result.code === 0) return true;
+  } catch {
+    // Retry smaller batches below.
+  }
+  if (refs.length === 1) return false;
+  const midpoint = Math.ceil(refs.length / 2);
+  const left = await releaseRefBatch(git, refs.slice(0, midpoint));
+  const right = await releaseRefBatch(git, refs.slice(midpoint));
+  return left && right;
+}
+
+export async function releaseRefs(
+  gitForRepository: (repository: GitRepository) => GitRunner,
+  refs: readonly RefRelease[],
+): Promise<boolean> {
+  const grouped = new Map<string, { repository: GitRepository; refs: RefRelease[] }>();
+  for (const ref of refs) {
+    const key = ref.repository.commonDir;
+    const group = grouped.get(key);
+    if (group) {
+      group.refs.push(ref);
+    } else {
+      grouped.set(key, { repository: ref.repository, refs: [ref] });
+    }
+  }
+
+  const results = await Promise.allSettled(
+    [...grouped.values()].map(async ({ repository, refs: groupedRefs }) => {
+      try {
+        return await releaseRefBatch(gitForRepository(repository), groupedRefs);
+      } catch {
+        return false;
+      }
+    }),
+  );
+  return results.every((result) => result.status === "fulfilled" && result.value);
+}
+
+export async function releaseCheckpoints(
+  gitForRepository: (repository: GitRepository) => GitRunner,
+  checkpoints: readonly GitCheckpoint[],
+): Promise<boolean> {
+  return releaseRefs(
+    gitForRepository,
+    checkpoints.flatMap((checkpoint) => [
+      {
+        repository: checkpoint.repository,
+        ref: checkpoint.beforeRef,
+        expectedHash: checkpoint.beforeHash,
+      },
+      {
+        repository: checkpoint.repository,
+        ref: checkpoint.afterRef,
+        expectedHash: checkpoint.afterHash,
+      },
+    ]),
+  );
 }
 
 export async function releaseCheckpoint(
   git: GitRunner,
   checkpoint: GitCheckpoint,
 ): Promise<boolean> {
-  const before = await releaseRef(git, checkpoint.beforeRef, checkpoint.beforeHash);
-  const after = await releaseRef(git, checkpoint.afterRef, checkpoint.afterHash);
-  return before && after;
+  return releaseRefs(
+    () => git,
+    [
+      {
+        repository: checkpoint.repository,
+        ref: checkpoint.beforeRef,
+        expectedHash: checkpoint.beforeHash,
+      },
+      {
+        repository: checkpoint.repository,
+        ref: checkpoint.afterRef,
+        expectedHash: checkpoint.afterHash,
+      },
+    ],
+  );
 }
 
 export async function releasePendingCheckpoint(
   git: GitRunner,
   pending: Pick<PendingCheckpoint, "beforeHash" | "beforeRef">,
 ): Promise<boolean> {
-  return releaseRef(git, pending.beforeRef, pending.beforeHash);
+  return releaseRefBatch(git, [{ ref: pending.beforeRef, expectedHash: pending.beforeHash }]);
 }
 
 export async function prepareBeforeTurn(

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -6,7 +6,7 @@ import type {
   NavigationPort,
   NavigationResult,
 } from "./types.js";
-import { applyCheckpoint, releaseCheckpoint } from "./checkpoints.js";
+import { applyCheckpoint, releaseCheckpoints } from "./checkpoints.js";
 
 export type NavigationOutcome = "moved" | "empty" | "cancelled" | "git_failed" | "rollback_failed";
 
@@ -45,18 +45,14 @@ export class SessionNavigation {
     );
     this.checkpoints.push(checkpoint);
     this.currentIndex = this.checkpoints.length - 1;
-    await Promise.all(
-      discarded.map((entry) => releaseCheckpoint(this.gitForRepository(entry.repository), entry)),
-    );
+    await releaseCheckpoints(this.gitForRepository, discarded);
   }
 
   async dispose(): Promise<void> {
     const checkpoints = this.checkpoints;
     this.checkpoints = [];
     this.currentIndex = -1;
-    await Promise.all(
-      checkpoints.map((entry) => releaseCheckpoint(this.gitForRepository(entry.repository), entry)),
-    );
+    await releaseCheckpoints(this.gitForRepository, checkpoints);
   }
 
   async undo(): Promise<NavigationOutcome> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,7 @@ export interface NavigationPort extends SessionReader {
 
 export interface GitRunOptions {
   env?: Record<string, string | undefined>;
+  stdin?: string;
 }
 
 export type GitRunner = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
 import type { SessionEntryLike } from "./core/types.js";
@@ -8,12 +8,26 @@ import { SessionNavigation } from "./core/session-navigation.js";
 import {
   finishAfterTurn,
   prepareBeforeTurn,
+  releaseCheckpoint,
   releasePendingCheckpoint,
 } from "./core/checkpoints.js";
 import type { GitRunner, PendingCheckpoint } from "./core/types.js";
 
 const execFileAsync = promisify(execFile);
 
+function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 type AnyContext = {
   cwd: string;
   sessionManager: {
@@ -26,6 +40,45 @@ type AnyContext = {
 
 function createGitRunner(cwd: string): GitRunner {
   return async (args, options) => {
+    if (options?.stdin !== undefined) {
+      const { promise, resolve } = promiseWithResolvers<{
+        stdout: string;
+        stderr: string;
+        code: number;
+      }>();
+      const child = spawn("git", args, {
+        cwd,
+        env: { ...process.env, ...options.env },
+        windowsHide: true,
+      });
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once("error", (error) => {
+        if (settled) return;
+        settled = true;
+        resolve({
+          stdout,
+          stderr: `${stderr}${error.message}`,
+          code: 1,
+        });
+      });
+      child.once("close", (code) => {
+        if (settled) return;
+        settled = true;
+        resolve({ stdout, stderr, code: typeof code === "number" ? code : 1 });
+      });
+      child.stdin.end(options.stdin);
+      return await promise;
+    }
     try {
       const result = await execFileAsync("git", args, {
         cwd,
@@ -61,58 +114,132 @@ function createNavigation(ctx: AnyContext): SessionNavigation {
   );
 }
 
-const navigations = new Map<string, SessionNavigation>();
-const pending = new Map<string, PendingCheckpoint>();
-
 export default function ompUndoRedo(pi: ExtensionAPI): void {
-  pi.on("session_start", async (_event, ctx) => {
-    const sessionId = ctx.sessionManager.getSessionId();
-    const previous = navigations.get(sessionId);
-    if (previous) await previous.dispose();
-    const previousPending = pending.get(sessionId);
-    if (previousPending) {
-      await releasePendingCheckpoint(
-        createGitRunner(previousPending.repository.worktree),
-        previousPending,
-      );
-    }
-    navigations.set(sessionId, createNavigation(ctx as unknown as AnyContext));
-    pending.delete(sessionId);
-  });
+  const navigations = new Map<string, SessionNavigation>();
+  const pending = new Map<string, PendingCheckpoint>();
+  const activeOperations = new Set<Promise<void>>();
+  let closing = false;
+  let shutdownPromise: Promise<void> | null = null;
 
-  pi.on("before_agent_start", async (_event, ctx) => {
-    const typed = ctx as unknown as AnyContext;
-    const sessionId = typed.sessionManager.getSessionId();
-    const oldPending = pending.get(sessionId);
-    if (oldPending) {
-      await releasePendingCheckpoint(createGitRunner(oldPending.repository.worktree), oldPending);
+  function track(operation: () => Promise<void>): Promise<void> {
+    const { promise: tracked, resolve, reject } = promiseWithResolvers<void>();
+    activeOperations.add(tracked);
+    void (async () => {
+      try {
+        await operation();
+        resolve();
+      } catch (error) {
+        reject(error);
+      } finally {
+        activeOperations.delete(tracked);
+      }
+    })();
+    return tracked;
+  }
+
+  async function releasePending(pendingCheckpoint: PendingCheckpoint): Promise<void> {
+    await releasePendingCheckpoint(
+      createGitRunner(pendingCheckpoint.repository.worktree),
+      pendingCheckpoint,
+    );
+  }
+
+  async function disposeDetached(
+    detachedNavigations: readonly SessionNavigation[],
+    detachedPending: readonly PendingCheckpoint[],
+  ): Promise<void> {
+    await Promise.allSettled([
+      ...detachedNavigations.map((navigation) => navigation.dispose()),
+      ...detachedPending.map((pendingCheckpoint) => releasePending(pendingCheckpoint)),
+    ]);
+  }
+
+  async function drainState(): Promise<void> {
+    const detachedNavigations = [...navigations.values()];
+    const detachedPending = [...pending.values()];
+    navigations.clear();
+    pending.clear();
+    await disposeDetached(detachedNavigations, detachedPending);
+  }
+
+  pi.on("session_start", (_event, ctx) =>
+    track(async () => {
+      if (closing) return;
+      const typed = ctx as unknown as AnyContext;
+      const sessionId = typed.sessionManager.getSessionId();
+      const previous = navigations.get(sessionId);
+      navigations.delete(sessionId);
+      const previousPending = pending.get(sessionId);
       pending.delete(sessionId);
-    }
-    const before = await prepareBeforeTurn(createGitRunner(typed.cwd), sessionId);
-    if (before) {
-      pending.set(sessionId, {
+      await disposeDetached(previous ? [previous] : [], previousPending ? [previousPending] : []);
+      if (closing) return;
+      navigations.set(sessionId, createNavigation(typed));
+    }),
+  );
+
+  pi.on("before_agent_start", (_event, ctx) =>
+    track(async () => {
+      if (closing) return;
+      const typed = ctx as unknown as AnyContext;
+      const sessionId = typed.sessionManager.getSessionId();
+      const oldPending = pending.get(sessionId);
+      pending.delete(sessionId);
+      if (oldPending) await releasePending(oldPending);
+      const before = await prepareBeforeTurn(createGitRunner(typed.cwd), sessionId);
+      if (!before) return;
+      const checkpoint = {
         ...before,
         parentLeafId: typed.sessionManager.getLeafId(),
-      });
-    }
-  });
+      };
+      if (closing) {
+        await releasePending(checkpoint);
+        return;
+      }
+      pending.set(sessionId, checkpoint);
+    }),
+  );
 
-  pi.on("agent_end", async (_event, ctx) => {
-    const typed = ctx as unknown as AnyContext;
-    const sessionId = typed.sessionManager.getSessionId();
-    const before = pending.get(sessionId);
-    if (!before) return;
-    pending.delete(sessionId);
-    const checkpoint = await finishAfterTurn(
-      createGitRunner(before.repository.worktree),
-      before,
-      before.parentLeafId,
-      typed.sessionManager.getLeafId(),
-    );
-    if (!checkpoint) return;
-    const nav = navigations.get(sessionId) ?? createNavigation(typed);
-    navigations.set(sessionId, nav);
-    await nav.recordTurnEnd(checkpoint);
+  pi.on("agent_end", (_event, ctx) =>
+    track(async () => {
+      const typed = ctx as unknown as AnyContext;
+      const sessionId = typed.sessionManager.getSessionId();
+      const before = pending.get(sessionId);
+      if (!before) return;
+      pending.delete(sessionId);
+      if (closing) {
+        await releasePending(before);
+        return;
+      }
+      const checkpoint = await finishAfterTurn(
+        createGitRunner(before.repository.worktree),
+        before,
+        before.parentLeafId,
+        typed.sessionManager.getLeafId(),
+      );
+      if (!checkpoint) return;
+      if (closing) {
+        await releaseCheckpoint(createGitRunner(checkpoint.repository.worktree), checkpoint);
+        return;
+      }
+      const nav = navigations.get(sessionId) ?? createNavigation(typed);
+      navigations.set(sessionId, nav);
+      await nav.recordTurnEnd(checkpoint);
+    }),
+  );
+
+  pi.on("session_shutdown", () => {
+    if (shutdownPromise) return shutdownPromise;
+    closing = true;
+    const detachedNavigations = [...navigations.values()];
+    const detachedPending = [...pending.values()];
+    navigations.clear();
+    pending.clear();
+    shutdownPromise = (async () => {
+      await disposeDetached(detachedNavigations, detachedPending);
+      await Promise.allSettled([...activeOperations]);
+      await drainState();
+    })();
+    return shutdownPromise;
   });
 
   const undoHandler = async (_args: string, ctx: ExtensionCommandContext) => {

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -1,4 +1,5 @@
-import { execFile } from "node:child_process";
+import { once } from "node:events";
+import { execFile, spawn } from "node:child_process";
 import {
   mkdir,
   chmod,
@@ -21,8 +22,9 @@ import {
   checkpointNamespace,
   finishAfterTurn,
   prepareBeforeTurn,
-  previousCheckpoint,
   releaseCheckpoint,
+  previousCheckpoint,
+  releaseRefs,
 } from "../src/core/checkpoints.js";
 import type {
   GitCheckpoint,
@@ -60,6 +62,30 @@ const entries: SessionEntryLike[] = [
 
 function gitRunner(cwd: string): GitRunner {
   return async (args, options) => {
+    if (options?.stdin !== undefined) {
+      const child = spawn("git", args, {
+        cwd,
+        env: { ...process.env, ...options.env },
+        windowsHide: true,
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.stdin.end(options.stdin);
+      try {
+        const [code] = (await once(child, "close")) as [number | null];
+        return { stdout, stderr, code: typeof code === "number" ? code : 1 };
+      } catch (error) {
+        return { stdout, stderr: `${stderr}${String(error)}`, code: 1 };
+      }
+    }
     try {
       const result = await execFileAsync("git", args, {
         cwd,
@@ -528,6 +554,48 @@ describe("history-safe Git checkpoints", () => {
       await git(["gc", "--prune=now"]);
       expect((await git(["cat-file", "-e", `${checkpoint.beforeHash}^{commit}`])).code).not.toBe(0);
       expect((await git(["cat-file", "-e", `${checkpoint.afterHash}^{commit}`])).code).not.toBe(0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("isolates a changed private ref without blocking valid cleanup", async () => {
+    const { cwd, git } = await makeRepo();
+    try {
+      await initializeBranch(git, cwd);
+      const before = await prepareBeforeTurn(git, "batch");
+      expect(before).not.toBeNull();
+      if (!before) return;
+      await writeFile(join(cwd, "tracked.txt"), "after\n");
+      const checkpoint = await finishAfterTurn(git, before, null, null);
+      expect(checkpoint).not.toBeNull();
+      if (!checkpoint) return;
+      await git(["update-ref", "refs/keep", "HEAD"]);
+      await git(["update-ref", checkpoint.afterRef, checkpoint.beforeHash]);
+
+      const released = await releaseRefs(
+        () => git,
+        [
+          {
+            repository: checkpoint.repository,
+            ref: checkpoint.beforeRef,
+            expectedHash: checkpoint.beforeHash,
+          },
+          {
+            repository: checkpoint.repository,
+            ref: checkpoint.afterRef,
+            expectedHash: checkpoint.afterHash,
+          },
+        ],
+      );
+
+      expect(released).toBe(false);
+      expect((await git(["show-ref", "--verify", checkpoint.beforeRef])).code).not.toBe(0);
+      expect((await git(["rev-parse", checkpoint.afterRef])).stdout.trim()).toBe(
+        checkpoint.beforeHash,
+      );
+      expect((await git(["rev-parse", "refs/keep"])).stdout.trim()).toBe(
+        (await git(["rev-parse", "HEAD"])).stdout.trim(),
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,0 +1,152 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import ompUndoRedo from "../src/index.js";
+
+const execFileAsync = promisify(execFile);
+type Handler = (...args: unknown[]) => unknown;
+
+type TestContext = {
+  cwd: string;
+  sessionManager: {
+    getSessionId(): string;
+    getLeafId(): string;
+    getBranch(): [];
+    getEntry(): undefined;
+  };
+};
+
+class FakeExtensionApi {
+  private readonly handlers = new Map<string, Handler>();
+
+  on(event: string, handler: Handler): void {
+    this.handlers.set(event, handler);
+  }
+
+  registerCommand(): void {
+    // Commands are not part of these lifecycle tests.
+  }
+
+  async emit(event: string, context: TestContext): Promise<void> {
+    const handler = this.handlers.get(event);
+    if (!handler) throw new Error(`No handler registered for ${event}`);
+    await handler({ type: event }, context);
+  }
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd, windowsHide: true });
+  return result.stdout.trim();
+}
+
+async function makeRepository(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-lifecycle-"));
+  await git(cwd, ["init", "-q"]);
+  await git(cwd, ["config", "user.name", "test"]);
+  await git(cwd, ["config", "user.email", "test@example.com"]);
+  await git(cwd, ["config", "core.autocrlf", "false"]);
+  await writeFile(join(cwd, "tracked.txt"), "base\n");
+  await git(cwd, ["add", "."]);
+  await git(cwd, ["commit", "-qm", "base"]);
+  return cwd;
+}
+
+function context(cwd: string, sessionId: string): TestContext {
+  return {
+    cwd,
+    sessionManager: {
+      getSessionId: () => sessionId,
+      getLeafId: () => "leaf",
+      getBranch: () => [],
+      getEntry: () => undefined,
+    },
+  };
+}
+
+async function privateRefs(cwd: string): Promise<string[]> {
+  const output = await git(cwd, ["for-each-ref", "--format=%(refname)", "refs/omp-undo-redo/"]);
+  return output ? output.split("\n") : [];
+}
+
+describe("extension lifecycle cleanup", () => {
+  it("releases completed checkpoints, pending checkpoints, and unrelated refs survive", async () => {
+    const cwd = await makeRepository();
+    try {
+      await git(cwd, ["update-ref", "refs/keep", "HEAD"]);
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = context(cwd, "session-one");
+
+      await pi.emit("session_start", ctx);
+      await pi.emit("before_agent_start", ctx);
+      await writeFile(join(cwd, "tracked.txt"), "changed\n");
+      await pi.emit("agent_end", ctx);
+      expect(await privateRefs(cwd)).toHaveLength(2);
+
+      await pi.emit("session_shutdown", ctx);
+      await pi.emit("session_shutdown", ctx);
+      expect(await privateRefs(cwd)).toEqual([]);
+      expect(await git(cwd, ["rev-parse", "refs/keep"])).toBe(
+        await git(cwd, ["rev-parse", "HEAD"]),
+      );
+
+      await pi.emit("session_start", ctx);
+      await pi.emit("before_agent_start", ctx);
+      await pi.emit("session_shutdown", ctx);
+      expect(await privateRefs(cwd)).toEqual([]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("drains pending checkpoints when shutdown interrupts a turn", async () => {
+    const cwd = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = context(cwd, "pending-session");
+
+      await pi.emit("session_start", ctx);
+      await pi.emit("before_agent_start", ctx);
+      expect(await privateRefs(cwd)).toHaveLength(1);
+      await pi.emit("session_shutdown", ctx);
+      expect(await privateRefs(cwd)).toEqual([]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("drains every in-memory session and repository", async () => {
+    const first = await makeRepository();
+    const second = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const firstContext = context(first, "first-session");
+      const secondContext = context(second, "second-session");
+
+      await pi.emit("session_start", firstContext);
+      await pi.emit("before_agent_start", firstContext);
+      await writeFile(join(first, "tracked.txt"), "first change\n");
+      await pi.emit("agent_end", firstContext);
+      await pi.emit("session_start", secondContext);
+      await pi.emit("before_agent_start", secondContext);
+      await writeFile(join(second, "tracked.txt"), "second change\n");
+      await pi.emit("agent_end", secondContext);
+      expect(await privateRefs(first)).toHaveLength(2);
+      expect(await privateRefs(second)).toHaveLength(2);
+
+      await pi.emit("session_shutdown", secondContext);
+      expect(await privateRefs(first)).toEqual([]);
+      expect(await privateRefs(second)).toEqual([]);
+    } finally {
+      await Promise.all([
+        rm(first, { recursive: true, force: true }),
+        rm(second, { recursive: true, force: true }),
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Release private checkpoint refs during graceful session shutdown.
- Batch compare-and-delete checkpoint refs safely.
- Bump package metadata and documentation to v1.0.20.

## Verification
- npm run verify