### PR TITLE
fix: navigate empty checkpoint turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.21] - 2026-07-29
+
+### Fixed
+
+- Allow `/undo` and `/redo` to navigate conversation-only turns whose snapshots have no file delta.
+- Allow turns that change only ignored files to navigate without a false worktree-conflict failure.
+- Preserve existing conflict handling for non-empty file deltas.
+
 ## [1.0.20] - 2026-07-29
 
 ### Fixed
@@ -130,7 +138,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
-[1.0.20]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.20
+[1.0.21]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.21
 [1.0.19]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.19
 [1.0.18]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.18
 [1.0.7]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.7

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.0.20
+omp plugin install @baylarsadigov/omp-undo-redo@1.0.21
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -58,7 +58,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.0.20
+pi install npm:@baylarsadigov/omp-undo-redo@1.0.21
 ```
 
 To update installed Pi packages:
@@ -78,6 +78,8 @@ The extension exposes exactly these commands:
 
 Commands take no arguments. They navigate OMP's session tree through the official extension API and do not create a new model turn.
 Both commands wait for the current agent turn to become idle; if OMP remains busy, the command leaves the session unchanged and shows a warning.
+
+Every completed turn remains undoable, including conversation-only turns and turns that change only ignored files. When the before and after snapshots have no tracked-file delta, `/undo` and `/redo` navigate the session tree without changing the worktree.
 
 ## Limitations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -264,8 +264,16 @@ export async function applyCheckpoint(
   const tempDirectory = await mkdtemp(join(tmpdir(), "omp-undo-redo-patch-"));
   const patchPath = join(tempDirectory, "checkpoint.patch");
   try {
-    const diff = await git(["diff", "--binary", sourceHash, targetHash, `--output=${patchPath}`]);
-    if (diff.code !== 0) return "failed";
+    const diff = await git([
+      "diff",
+      "--exit-code",
+      "--binary",
+      sourceHash,
+      targetHash,
+      `--output=${patchPath}`,
+    ]);
+    if (diff.code === 0) return "applied";
+    if (diff.code !== 1) return "failed";
 
     const check = await git(["apply", "--check", patchPath]);
     if (check.code !== 0) return "conflict";

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -223,6 +223,108 @@ describe("history-safe Git checkpoints", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("navigates a completed turn with no file changes", async () => {
+    const { cwd, git } = await makeRepo();
+    try {
+      await initializeBranch(git, cwd);
+      const beforeHead = await text(git, ["rev-parse", "HEAD"]);
+      const beforeRefs = await branchRefs(git);
+      const beforeIndex = await indexState(git, cwd);
+      const beforeContents = await readFile(join(cwd, "tracked.txt"), "utf8");
+
+      const pending = await prepareBeforeTurn(git, "empty-turn");
+      expect(pending).not.toBeNull();
+      if (!pending) return;
+      const checkpoint = await finishAfterTurn(git, pending, "u1", "a1");
+      expect(checkpoint).not.toBeNull();
+      if (!checkpoint) return;
+      expect(await text(git, ["rev-parse", `${checkpoint.beforeHash}^{tree}`])).toBe(
+        await text(git, ["rev-parse", `${checkpoint.afterHash}^{tree}`]),
+      );
+
+      const navigated: string[] = [];
+      const navigationPort: NavigationPort = {
+        getLeafId: () => "a1",
+        getBranch: () => [],
+        getEntry: () => undefined,
+        navigateTree: async (targetId) => {
+          navigated.push(targetId);
+          return { cancelled: false };
+        },
+      };
+      const navigation = new SessionNavigation(navigationPort, git);
+      await navigation.recordTurnEnd(checkpoint);
+
+      expect(await navigation.undo()).toBe("moved");
+      expect(navigated).toEqual(["u1"]);
+      expect(navigation.getLastGitFailure()).toBeNull();
+      expect(await navigation.redo()).toBe("moved");
+      expect(navigated).toEqual(["u1", "a1"]);
+      expect(navigation.getLastGitFailure()).toBeNull();
+
+      expect(await text(git, ["rev-parse", "HEAD"])).toBe(beforeHead);
+      expect(await branchRefs(git)).toBe(beforeRefs);
+      expect(await indexState(git, cwd)).toEqual(beforeIndex);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe(beforeContents);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("navigates a turn that changes only ignored files", async () => {
+    const { cwd, git } = await makeRepo();
+    const ignoredPath = join(cwd, "ignored.txt");
+    try {
+      await initializeBranch(git, cwd);
+      await writeFile(join(cwd, ".gitignore"), "ignored.txt\n");
+      await git(["add", ".gitignore"]);
+      await git(["commit", "-qm", "ignore fixture"]);
+      const beforeHead = await text(git, ["rev-parse", "HEAD"]);
+      const beforeRefs = await branchRefs(git);
+      const beforeIndex = await indexState(git, cwd);
+      const beforeContents = await readFile(join(cwd, "tracked.txt"), "utf8");
+
+      const pending = await prepareBeforeTurn(git, "ignored-turn");
+      expect(pending).not.toBeNull();
+      if (!pending) return;
+      await writeFile(ignoredPath, "ignored after turn\n");
+      const checkpoint = await finishAfterTurn(git, pending, "u1", "a1");
+      expect(checkpoint).not.toBeNull();
+      if (!checkpoint) return;
+      expect(await text(git, ["rev-parse", `${checkpoint.beforeHash}^{tree}`])).toBe(
+        await text(git, ["rev-parse", `${checkpoint.afterHash}^{tree}`]),
+      );
+
+      const navigated: string[] = [];
+      const navigationPort: NavigationPort = {
+        getLeafId: () => "a1",
+        getBranch: () => [],
+        getEntry: () => undefined,
+        navigateTree: async (targetId) => {
+          navigated.push(targetId);
+          return { cancelled: false };
+        },
+      };
+      const navigation = new SessionNavigation(navigationPort, git);
+      await navigation.recordTurnEnd(checkpoint);
+
+      expect(await navigation.undo()).toBe("moved");
+      expect(navigated).toEqual(["u1"]);
+      expect(navigation.getLastGitFailure()).toBeNull();
+      expect(await navigation.redo()).toBe("moved");
+      expect(navigated).toEqual(["u1", "a1"]);
+      expect(navigation.getLastGitFailure()).toBeNull();
+
+      expect(await text(git, ["rev-parse", "HEAD"])).toBe(beforeHead);
+      expect(await branchRefs(git)).toBe(beforeRefs);
+      expect(await indexState(git, cwd)).toEqual(beforeIndex);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe(beforeContents);
+      expect(await readFile(ignoredPath, "utf8")).toBe("ignored after turn\n");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it("preserves pre-existing changes outside a subdirectory session across undo and redo", async () => {
     const { cwd, git } = await makeRepo();
     const nested = join(cwd, "nested");


### PR DESCRIPTION
Fix /undo and /redo for conversation-only turns and turns that change only ignored files. Empty Git deltas now apply as successful no-ops; non-empty conflict handling is unchanged. Includes integration coverage and release documentation.