### PR TITLE
Fix redo invalidation after external navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.22] - 2026-07-29
+
+### Fixed
+
+- Clear redo history after successful unrelated session-tree, session-switch, or session-branch navigation while preserving undo history.
+- Keep redo available for matching extension-generated navigation, no-op navigation, and cancelled navigation.
+
 ## [1.0.21] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.0.21
+omp plugin install @baylarsadigov/omp-undo-redo@1.0.22
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -58,7 +58,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.0.21
+pi install npm:@baylarsadigov/omp-undo-redo@1.0.22
 ```
 
 To update installed Pi packages:
@@ -74,7 +74,7 @@ Use `pi list` to confirm the package is installed, then restart the Pi TUI. The 
 The extension exposes exactly these commands:
 
 - `/undo` — move to the latest user-prompt boundary, removing that prompt's assistant/tool activity from the active context. The prompt itself remains as the supported OMP session-tree boundary. If the current context is already at that boundary, it reports that undo is unavailable.
-- `/redo` — restore the most recently undone context checkpoint. Redo is single-use in order: after a new branch or any navigation that is not the matching redo, the in-memory redo history is cleared.
+- `/redo` — restore the most recently undone context checkpoint. Redo is single-use in order: after a new branch or any successful, unrelated tree, session-switch, or session-branch navigation, the in-memory redo history is cleared. Matching `/undo` and `/redo` navigation, no-op navigation, and cancelled navigation preserve redo.
 
 Commands take no arguments. They navigate OMP's session tree through the official extension API and do not create a new model turn.
 Both commands wait for the current agent turn to become idle; if OMP remains busy, the command leaves the session unchanged and shows a warning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -12,10 +12,16 @@ export type NavigationOutcome = "moved" | "empty" | "cancelled" | "git_failed" |
 
 type GitFailure = "conflict" | "failed" | "rollback_failed";
 
+type ExpectedTreeNavigation = {
+  oldLeafId: string | null;
+  newLeafId: string | null;
+};
+
 export class SessionNavigation {
   private checkpoints: GitCheckpoint[] = [];
   private currentIndex = -1;
   private navigateTree: NavigationPort["navigateTree"] = async () => ({ cancelled: true });
+  private expectedTreeNavigation: ExpectedTreeNavigation | null = null;
   private lastGitFailure: GitFailure | null = null;
   private readonly gitForRepository: GitRunnerFactory;
 
@@ -32,6 +38,38 @@ export class SessionNavigation {
 
   setNavigateTree(navigateTree: NavigationPort["navigateTree"]): void {
     this.navigateTree = navigateTree;
+  }
+
+  private async navigateTo(targetId: string): Promise<NavigationResult> {
+    this.expectedTreeNavigation = {
+      oldLeafId: this.port.getLeafId(),
+      newLeafId: targetId,
+    };
+    try {
+      return await this.navigateTree(targetId);
+    } catch {
+      return { cancelled: true };
+    } finally {
+      this.expectedTreeNavigation = null;
+    }
+  }
+
+  async handleSessionTreeNavigation(
+    oldLeafId: string | null,
+    newLeafId: string | null,
+  ): Promise<void> {
+    const expected = this.expectedTreeNavigation;
+    if (expected && expected.oldLeafId === oldLeafId && expected.newLeafId === newLeafId) {
+      this.expectedTreeNavigation = null;
+      return;
+    }
+    if (oldLeafId === newLeafId) return;
+    await this.invalidateRedo();
+  }
+
+  async invalidateRedo(): Promise<void> {
+    const discarded = this.checkpoints.splice(this.currentIndex + 1);
+    await releaseCheckpoints(this.gitForRepository, discarded);
   }
 
   getLastGitFailure(): GitFailure | null {
@@ -68,7 +106,7 @@ export class SessionNavigation {
     if (checkpoint.parentLeafId) {
       let result: NavigationResult;
       try {
-        result = await this.navigateTree(checkpoint.parentLeafId);
+        result = await this.navigateTo(checkpoint.parentLeafId);
       } catch {
         result = { cancelled: true };
       }
@@ -98,7 +136,7 @@ export class SessionNavigation {
     if (checkpoint.leafId) {
       let result: NavigationResult;
       try {
-        result = await this.navigateTree(checkpoint.leafId);
+        result = await this.navigateTo(checkpoint.leafId);
       } catch {
         result = { cancelled: true };
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,8 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
   const activeOperations = new Set<Promise<void>>();
   let closing = false;
   let shutdownPromise: Promise<void> | null = null;
+  let pendingSwitchSourceSessionId: string | null = null;
+  let pendingBranchSourceSessionId: string | null = null;
 
   function track(operation: () => Promise<void>): Promise<void> {
     const { promise: tracked, resolve, reject } = promiseWithResolvers<void>();
@@ -154,6 +156,12 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     ]);
   }
 
+  async function invalidateAllRedo(): Promise<void> {
+    await Promise.allSettled(
+      [...navigations.values()].map((navigation) => navigation.invalidateRedo()),
+    );
+  }
+
   async function drainState(): Promise<void> {
     const detachedNavigations = [...navigations.values()];
     const detachedPending = [...pending.values()];
@@ -174,6 +182,58 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
       await disposeDetached(previous ? [previous] : [], previousPending ? [previousPending] : []);
       if (closing) return;
       navigations.set(sessionId, createNavigation(typed));
+    }),
+  );
+
+  pi.on("session_tree", (event, ctx) =>
+    track(async () => {
+      if (closing) return;
+      const typed = ctx as unknown as AnyContext;
+      const navigation = navigations.get(typed.sessionManager.getSessionId());
+      if (!navigation) return;
+      await navigation.handleSessionTreeNavigation(event.oldLeafId, event.newLeafId);
+    }),
+  );
+
+  pi.on("session_before_switch", (_event, ctx) =>
+    track(async () => {
+      if (closing) return;
+      const typed = ctx as unknown as AnyContext;
+      pendingSwitchSourceSessionId = typed.sessionManager.getSessionId();
+    }),
+  );
+
+  pi.on("session_switch", () =>
+    track(async () => {
+      if (closing) return;
+      const sourceSessionId = pendingSwitchSourceSessionId;
+      pendingSwitchSourceSessionId = null;
+      if (sourceSessionId) {
+        await navigations.get(sourceSessionId)?.invalidateRedo();
+      } else {
+        await invalidateAllRedo();
+      }
+    }),
+  );
+
+  pi.on("session_before_branch", (_event, ctx) =>
+    track(async () => {
+      if (closing) return;
+      const typed = ctx as unknown as AnyContext;
+      pendingBranchSourceSessionId = typed.sessionManager.getSessionId();
+    }),
+  );
+
+  pi.on("session_branch", () =>
+    track(async () => {
+      if (closing) return;
+      const sourceSessionId = pendingBranchSourceSessionId;
+      pendingBranchSourceSessionId = null;
+      if (sourceSessionId) {
+        await navigations.get(sourceSessionId)?.invalidateRedo();
+      } else {
+        await invalidateAllRedo();
+      }
     }),
   );
 
@@ -230,6 +290,8 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
   pi.on("session_shutdown", () => {
     if (shutdownPromise) return shutdownPromise;
     closing = true;
+    pendingSwitchSourceSessionId = null;
+    pendingBranchSourceSessionId = null;
     const detachedNavigations = [...navigations.values()];
     const detachedPending = [...pending.values()];
     navigations.clear();

--- a/test/command-behavior.test.ts
+++ b/test/command-behavior.test.ts
@@ -94,6 +94,65 @@ describe("session navigation", () => {
     expect(await navigation.redo()).toBe("empty");
   });
 
+  it("preserves redo for matching internal tree navigation", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    navigation.setNavigateTree(async (targetId) => {
+      const oldLeafId = session.leaf;
+      session.navigateCalls.push(targetId);
+      session.leaf = targetId;
+      await navigation.handleSessionTreeNavigation(oldLeafId, targetId);
+      return { cancelled: false };
+    });
+    await navigation.recordTurnEnd(checkpoint("u1", "a1"));
+    await navigation.recordTurnEnd(checkpoint("u2", "a2"));
+
+    expect(await navigation.undo()).toBe("moved");
+    expect(await navigation.redo()).toBe("moved");
+    expect(await navigation.redo()).toBe("empty");
+  });
+
+  it("invalidates only redo after unrelated tree navigation", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(checkpoint("u1", "a1"));
+    await navigation.recordTurnEnd(checkpoint("u2", "a2"));
+    expect(await navigation.undo()).toBe("moved");
+
+    await navigation.handleSessionTreeNavigation("u2", "other");
+
+    expect(await navigation.redo()).toBe("empty");
+    expect(session.navigateCalls).toEqual(["u2"]);
+    expect(await navigation.undo()).toBe("moved");
+    expect(session.navigateCalls).toEqual(["u2", "u1"]);
+  });
+
+  it("treats same-leaf tree events as no-ops", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(checkpoint("u1", "a1"));
+    await navigation.recordTurnEnd(checkpoint("u2", "a2"));
+    expect(await navigation.undo()).toBe("moved");
+
+    await navigation.handleSessionTreeNavigation("u2", "u2");
+
+    expect(await navigation.redo()).toBe("moved");
+  });
+
+  it("clears an expected transition after cancelled navigation", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(checkpoint("u1", "a1"));
+    await navigation.recordTurnEnd(checkpoint("u2", "a2"));
+    expect(await navigation.undo()).toBe("moved");
+    navigation.setNavigateTree(async () => ({ cancelled: true }));
+
+    expect(await navigation.redo()).toBe("cancelled");
+    await navigation.handleSessionTreeNavigation("u2", "a2");
+
+    expect(await navigation.redo()).toBe("empty");
+  });
+
   it("clears forward checkpoints on a new branch", async () => {
     const session = port();
     const navigation = makeNavigation(session);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -11,30 +11,72 @@ type Handler = (...args: unknown[]) => unknown;
 
 type TestContext = {
   cwd: string;
+  leaf: string;
   sessionManager: {
     getSessionId(): string;
     getLeafId(): string;
     getBranch(): [];
     getEntry(): undefined;
   };
+  navigateTree(targetId: string): Promise<{ cancelled: boolean }>;
+  waitForIdle(): Promise<void>;
+  isIdle(): boolean;
+  ui: {
+    notifications: Array<{ message: string; level: string }>;
+    notify(message: string, level: string): void;
+  };
 };
 
 class FakeExtensionApi {
   private readonly handlers = new Map<string, Handler>();
+  private readonly commands = new Map<string, Handler>();
 
   on(event: string, handler: Handler): void {
     this.handlers.set(event, handler);
   }
 
-  registerCommand(): void {
-    // Commands are not part of these lifecycle tests.
+  registerCommand(name: string, config: { handler: Handler }): void {
+    this.commands.set(name, config.handler);
   }
 
-  async emit(event: string, context: TestContext): Promise<void> {
+  async runCommand(name: string, context: TestContext): Promise<void> {
+    const handler = this.commands.get(name);
+    if (!handler) throw new Error(`No command registered for ${name}`);
+    await handler("", context);
+  }
+
+  async emit(
+    event: string,
+    context: TestContext,
+    payload?: Record<string, unknown>,
+  ): Promise<void> {
     const handler = this.handlers.get(event);
     if (!handler) throw new Error(`No handler registered for ${event}`);
-    await handler({ type: event }, context);
+    await handler(payload ?? { type: event }, context);
   }
+}
+
+function context(cwd: string, sessionId: string): TestContext {
+  const value: TestContext = {
+    cwd,
+    leaf: "leaf",
+    sessionManager: {
+      getSessionId: () => sessionId,
+      getLeafId: () => value.leaf,
+      getBranch: () => [],
+      getEntry: () => undefined,
+    },
+    navigateTree: async () => ({ cancelled: true }),
+    waitForIdle: async () => {},
+    isIdle: () => true,
+    ui: {
+      notifications: [],
+      notify(message, level) {
+        value.ui.notifications.push({ message, level });
+      },
+    },
+  };
+  return value;
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
@@ -54,22 +96,98 @@ async function makeRepository(): Promise<string> {
   return cwd;
 }
 
-function context(cwd: string, sessionId: string): TestContext {
-  return {
-    cwd,
-    sessionManager: {
-      getSessionId: () => sessionId,
-      getLeafId: () => "leaf",
-      getBranch: () => [],
-      getEntry: () => undefined,
-    },
-  };
-}
-
 async function privateRefs(cwd: string): Promise<string[]> {
   const output = await git(cwd, ["for-each-ref", "--format=%(refname)", "refs/omp-undo-redo/"]);
   return output ? output.split("\n") : [];
 }
+
+async function prepareUndoneSession(
+  pi: FakeExtensionApi,
+  cwd: string,
+  sessionId: string,
+): Promise<TestContext> {
+  const ctx = context(cwd, sessionId);
+  await pi.emit("session_start", ctx);
+  await pi.emit("before_agent_start", ctx);
+  await writeFile(join(cwd, "tracked.txt"), "changed\n");
+  ctx.leaf = "turn";
+  await pi.emit("agent_end", ctx);
+  ctx.navigateTree = async (targetId) => {
+    const oldLeafId = ctx.leaf;
+    ctx.leaf = targetId;
+    await pi.emit("session_tree", ctx, {
+      type: "session_tree",
+      oldLeafId,
+      newLeafId: targetId,
+    });
+    return { cancelled: false };
+  };
+  await pi.runCommand("undo", ctx);
+  return ctx;
+}
+
+describe("navigation invalidation lifecycle", () => {
+  it("clears redo after unrelated session tree navigation", async () => {
+    const cwd = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = await prepareUndoneSession(pi, cwd, "tree-session");
+
+      const oldLeafId = ctx.leaf;
+      ctx.leaf = "unrelated";
+      await pi.emit("session_tree", ctx, {
+        type: "session_tree",
+        oldLeafId,
+        newLeafId: ctx.leaf,
+      });
+      await pi.runCommand("redo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("base\n");
+      expect(ctx.ui.notifications.at(-1)?.message).toBe("Nothing to redo in this session.");
+      expect(await privateRefs(cwd)).toEqual([]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("clears redo for successful source session switches and branches", async () => {
+    for (const event of ["session_switch", "session_branch"] as const) {
+      const cwd = await makeRepository();
+      try {
+        const pi = new FakeExtensionApi();
+        ompUndoRedo(pi as never);
+        const ctx = await prepareUndoneSession(pi, cwd, `${event}-session`);
+        const beforeEvent =
+          event === "session_switch" ? "session_before_switch" : "session_before_branch";
+        await pi.emit(beforeEvent, ctx);
+        await pi.emit(event, ctx);
+        await pi.runCommand("redo", ctx);
+
+        expect(ctx.ui.notifications.at(-1)?.message).toBe("Nothing to redo in this session.");
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("preserves redo when a switch is cancelled before its post-event", async () => {
+    const cwd = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = await prepareUndoneSession(pi, cwd, "cancelled-switch-session");
+
+      await pi.emit("session_before_switch", ctx);
+      await pi.runCommand("redo", ctx);
+
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Redid last turn: session moved forward and file snapshot restored.",
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("extension lifecycle cleanup", () => {
   it("releases completed checkpoints, pending checkpoints, and unrelated refs survive", async () => {


### PR DESCRIPTION
## Summary\n- invalidate only forward redo checkpoints after unrelated tree, switch, or branch navigation\n- preserve matching undo/redo transitions, no-op navigation, cancellation, and older undo history\n- release discarded checkpoint refs and add regression coverage\n- bump package to v1.0.22