### PR TITLE
feat: preserve undo history without Git snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.23] - 2026-07-29
+
+### Fixed
+
+- Keep every completed turn available for session-only undo/redo when Git file checkpointing is unavailable.
+- Support full file checkpoints in initialized unborn Git repositories without changing `HEAD`, branch refs, or the real index.
+- Report stable checkpoint-unavailability reasons in `/undo` and `/redo` notifications.
+
 ## [1.0.22] - 2026-07-29
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve OMP Undo/Redo. Contributions should preserve the narrow scope of the extension: session-tree navigation only, using public OMP extension APIs.
+Thanks for helping improve OMP Undo/Redo. Contributions should preserve the narrow scope of the extension: session-tree navigation and Git-backed file-delta restoration when Git is available, using public OMP extension APIs.
 
 ## Before opening a change
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -2,24 +2,29 @@
 
 ## Goal
 
-Provide predictable `/undo` and `/redo` navigation for OMP sessions without modifying OMP's core or promising rollback of external effects.
+Provide predictable `/undo` and `/redo` navigation for OMP sessions with transactional file restoration when Git is available, without modifying OMP's core or promising rollback of external effects.
 
 ## Design
 
 1. Register one compiled extension entry through the package manifest's `omp.extensions` field.
 2. Observe the current session branch through the official OMP session/extension context APIs.
-3. Define an undo checkpoint as the entry immediately before the latest completed user interaction.
+3. Define a completed turn as either a full Git checkpoint or a session-only checkpoint with an explicit file-checkpoint unavailability reason.
 4. Navigate with OMP's tree-navigation API, allowing lifecycle cancellation to remain authoritative.
-5. Record only valid navigation targets in an in-memory redo state. Clear that state when the user creates a new branch, reloads the extension, or performs unrelated navigation.
-6. Expose exactly two argument-free slash commands: `/undo` and `/redo`.
+5. Apply Git file deltas only for full checkpoints; session-only checkpoints navigate session context without changing files.
+6. Record checkpoints in one ordered in-memory history. Clear redo state when the user creates a new branch, reloads the extension, or performs unrelated navigation.
+7. Expose exactly two argument-free slash commands: `/undo` and `/redo`.
 
 ## Compatibility and safety
 
 - Target Node.js 20 or newer and test against OMP 16.5.2.
 - Use public OMP APIs only; do not depend on internal modules or mutate session files.
+- Git is required for file restoration, but session undo/redo remains available outside Git.
+- Initialized unborn repositories are supported through an alternate empty index; an existing commit is not required.
+- Preserve `HEAD`, branch refs, and the real Git index. Keep private checkpoint refs isolated under `refs/omp-undo-redo/`.
 - Keep redo state ephemeral and validate targets before navigation.
-- Document that files and other external effects are never reverted.
+- Report stable checkpoint failure reasons without exposing raw Git stderr.
+- Document that external effects such as shell, network, editor, and ignored-file state are outside the checkpoint.
 
 ## Verification and release
 
-Use deterministic unit tests for checkpoint selection, target validation, redo invalidation, and command outcomes. Run type-checking, lint, formatting checks, tests, build, and package dry-run before release. Publish only the manifest-declared compiled entry and the package documentation/license files.
+Use deterministic unit and lifecycle tests for checkpoint selection, unborn repositories, session-only fallback, target validation, redo invalidation, cleanup, and command outcomes. Run type-checking, lint, formatting checks, tests, build, and package dry-run before release. Publish only the manifest-declared compiled entry and the package documentation/license files.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The extension uses the shared extension APIs provided by compatible OMP and Pi r
 
 - Node.js 20 or newer.
 - A compatible OMP or Pi release.
+- Git is required for file restoration. Session undo/redo remains available outside Git.
+
+An initialized Git repository does not need an existing commit. In an unborn repository, the extension creates full file checkpoints from an empty index.
 
 ## Installation
 
@@ -32,7 +35,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.0.22
+omp plugin install @baylarsadigov/omp-undo-redo@1.0.23
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -58,7 +61,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.0.22
+pi install npm:@baylarsadigov/omp-undo-redo@1.0.23
 ```
 
 To update installed Pi packages:
@@ -79,11 +82,11 @@ The extension exposes exactly these commands:
 Commands take no arguments. They navigate OMP's session tree through the official extension API and do not create a new model turn.
 Both commands wait for the current agent turn to become idle; if OMP remains busy, the command leaves the session unchanged and shows a warning.
 
-Every completed turn remains undoable, including conversation-only turns and turns that change only ignored files. When the before and after snapshots have no tracked-file delta, `/undo` and `/redo` navigate the session tree without changing the worktree.
+Every completed turn remains undoable, including conversation-only turns and turns that change only ignored files. When a Git file checkpoint is available, `/undo` and `/redo` restore the corresponding worktree delta as part of the same operation. If Git checkpoint creation is unavailable, the commands navigate session context only, leave files unchanged, and explicitly report that limitation.
 
 ## Limitations
 
-Undo/redo creates private Git snapshot objects through an alternate index and `git commit-tree`, then retains them with refs under `refs/omp-undo-redo/`. Checkpoint creation never moves `HEAD` or any branch ref. `/undo` and `/redo` apply file deltas only; they do not undo commits or branch switches. The real Git index is preserved, and releasing a checkpoint removes its private refs. A checkpoint covers the complete Git worktree that contains the session cwd; starting OMP from a repository subdirectory does not limit undo/redo to that subtree. Dirty files that existed before the turn are included in both snapshots and remain unchanged by undo/redo. Changes made anywhere in the repository during the turn can be part of the checkpoint because Git snapshots cannot determine authorship; this is an architectural limitation. The supported guarantee is: restores the non-ignored file changes represented by the checkpoint while preserving Git branch history and the real index. Ignored files, empty directories, dirty submodule contents, shell effects, network effects, and editor state are outside the checkpoint. Clean/smudge filters, `core.autocrlf`, submodules, and ignored files prevent a universal byte-for-byte guarantee. If overlapping worktree changes prevent safe application, undo/redo fails instead of overwriting them. Graceful session shutdown releases active and pending private refs. Forced termination, process kill, shutdown-handler timeout, or Git cleanup failure can still leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed stale refs. Do not delete refs from a repository while another OMP process may still be using them.
+Undo/redo has two modes. **Full mode** creates private Git snapshot objects through an alternate index and `git commit-tree`, then retains them with refs under `refs/omp-undo-redo/`; `/undo` and `/redo` apply the file delta and navigate session context. **Session-only mode** navigates session context without changing files when Git is unavailable, the cwd is outside a repository, the repository cannot be resolved, `HEAD` is invalid, or snapshot creation fails. Checkpoint creation never moves `HEAD` or any branch ref. The real Git index is preserved, and releasing a checkpoint removes its private refs. A checkpoint covers the complete Git worktree that contains the session cwd; starting OMP from a repository subdirectory does not limit undo/redo to that subtree. Dirty files that existed before the turn are included in both snapshots and remain unchanged by undo/redo. Changes made anywhere in the repository during the turn can be part of the checkpoint because Git snapshots cannot determine authorship; this is an architectural limitation. Ignored files, empty directories, dirty submodule contents, shell effects, network effects, and editor state are outside the checkpoint. Clean/smudge filters, `core.autocrlf`, submodules, and ignored files prevent a universal byte-for-byte guarantee. If overlapping worktree changes prevent safe application, undo/redo fails instead of overwriting them. Graceful session shutdown releases active and pending private refs. Forced termination, process kill, shutdown-handler timeout, or Git cleanup failure can still leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed stale refs. Do not delete refs from a repository while another OMP process may still be using them.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/commands/redo.ts
+++ b/src/commands/redo.ts
@@ -1,5 +1,21 @@
 import type { ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+import type { FileCheckpointUnavailableReason, NavigationResult } from "../core/types.js";
 import type { SessionNavigation } from "../core/session-navigation.js";
+
+function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
+  switch (reason) {
+    case "git_unavailable":
+      return "Git was unavailable when the checkpoint was created.";
+    case "not_repository":
+      return "the working directory is not a Git repository.";
+    case "repository_unresolvable":
+      return "the Git repository could not be resolved.";
+    case "invalid_head":
+      return "the Git repository has an invalid HEAD.";
+    default:
+      return "the file checkpoint could not be created.";
+  }
+}
 
 export async function runRedo(
   navigation: SessionNavigation,
@@ -11,16 +27,21 @@ export async function runRedo(
     return;
   }
 
-  const outcome = await navigation.redo();
-  switch (outcome) {
+  const outcome: NavigationResult = await navigation.redo();
+  switch (outcome.status) {
     case "moved":
-      ctx.ui.notify("Redid last turn: session moved forward and file snapshot restored.", "info");
+      ctx.ui.notify(
+        outcome.files === "restored"
+          ? "Redid last turn: session moved forward and file snapshot restored."
+          : `Redid the session turn, but files were not restored because ${unavailableMessage(outcome.reason)}`,
+        "info",
+      );
       break;
     case "empty":
       ctx.ui.notify("Nothing to redo in this session.", "info");
       break;
     case "cancelled":
-      ctx.ui.notify("Redo was cancelled; files were restored to their original state.", "warning");
+      ctx.ui.notify("Redo was cancelled; the session and files were left unchanged.", "warning");
       break;
     case "rollback_failed":
       ctx.ui.notify(
@@ -30,13 +51,11 @@ export async function runRedo(
       break;
     case "git_failed":
       ctx.ui.notify(
-        navigation.getLastGitFailure() === "conflict"
+        outcome.failure === "conflict"
           ? "Worktree changed; nothing was redone."
           : "Could not restore the Git checkpoint.",
         "warning",
       );
       break;
-    default:
-      ctx.ui.notify("Nothing to redo in this session.", "warning");
   }
 }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -1,5 +1,21 @@
 import type { ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+import type { FileCheckpointUnavailableReason, NavigationResult } from "../core/types.js";
 import type { SessionNavigation } from "../core/session-navigation.js";
+
+function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
+  switch (reason) {
+    case "git_unavailable":
+      return "Git was unavailable when the checkpoint was created.";
+    case "not_repository":
+      return "the working directory is not a Git repository.";
+    case "repository_unresolvable":
+      return "the Git repository could not be resolved.";
+    case "invalid_head":
+      return "the Git repository has an invalid HEAD.";
+    default:
+      return "the file checkpoint could not be created.";
+  }
+}
 
 export async function runUndo(
   navigation: SessionNavigation,
@@ -11,16 +27,21 @@ export async function runUndo(
     return;
   }
 
-  const outcome = await navigation.undo();
-  switch (outcome) {
+  const outcome: NavigationResult = await navigation.undo();
+  switch (outcome.status) {
     case "moved":
-      ctx.ui.notify("Undid last turn: session moved back and file snapshot restored.", "info");
+      ctx.ui.notify(
+        outcome.files === "restored"
+          ? "Undid last turn: session moved back and file snapshot restored."
+          : `Undid the session turn, but files were not restored because ${unavailableMessage(outcome.reason)}`,
+        "info",
+      );
       break;
     case "empty":
       ctx.ui.notify("Nothing to undo in this session.", "info");
       break;
     case "cancelled":
-      ctx.ui.notify("Undo was cancelled; files were restored to their original state.", "warning");
+      ctx.ui.notify("Undo was cancelled; the session and files were left unchanged.", "warning");
       break;
     case "rollback_failed":
       ctx.ui.notify(
@@ -30,13 +51,11 @@ export async function runUndo(
       break;
     case "git_failed":
       ctx.ui.notify(
-        navigation.getLastGitFailure() === "conflict"
+        outcome.failure === "conflict"
           ? "Worktree changed; nothing was undone."
           : "Could not restore the Git checkpoint.",
         "warning",
       );
       break;
-    default:
-      ctx.ui.notify("Nothing to undo in this session.", "warning");
   }
 }

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -1,12 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import type {
+  FileCheckpointUnavailableReason,
   GitCheckpoint,
   GitRepository,
   GitRunner,
-  PendingCheckpoint,
+  PendingGitCheckpoint,
   SessionReader,
 } from "./types.js";
 
@@ -26,23 +27,22 @@ function checkpointRefs(
   return { beforeRef: `${prefix}/before`, afterRef: `${prefix}/after` };
 }
 
-async function run(git: GitRunner, args: string[]): Promise<boolean> {
+type GitCommandResult = Awaited<ReturnType<GitRunner>>;
+
+async function invoke(
+  git: GitRunner,
+  args: string[],
+  options?: Parameters<GitRunner>[1],
+): Promise<GitCommandResult> {
   try {
-    return (await git(args)).code === 0;
+    return await git(args, options);
   } catch {
-    return false;
+    return { stdout: "", stderr: "", code: 1, error: "unavailable" };
   }
 }
 
-async function output(git: GitRunner, args: string[]): Promise<string | null> {
-  try {
-    const result = await git(args);
-    if (result.code !== 0) return null;
-    const value = result.stdout.trim();
-    return value || null;
-  } catch {
-    return null;
-  }
+async function run(git: GitRunner, args: string[]): Promise<boolean> {
+  return (await invoke(git, args)).code === 0;
 }
 
 async function canonicalPath(value: string, base: string): Promise<string> {
@@ -54,38 +54,97 @@ async function canonicalPath(value: string, base: string): Promise<string> {
   }
 }
 
-async function resolveRepository(git: GitRunner): Promise<GitRepository | null> {
-  const worktree = await output(git, ["rev-parse", "--show-toplevel"]);
-  const gitDir = await output(git, ["rev-parse", "--git-dir"]);
-  const commonDir = await output(git, ["rev-parse", "--git-common-dir"]);
-  if (!worktree || !gitDir || !commonDir) return null;
+type RepositoryResolution =
+  | { repository: GitRepository }
+  | { reason: "git_unavailable" | "not_repository" | "repository_unresolvable" };
+
+async function resolveRepository(git: GitRunner): Promise<RepositoryResolution> {
+  const worktreeResult = await invoke(git, ["rev-parse", "--show-toplevel"]);
+  if (worktreeResult.error === "unavailable") return { reason: "git_unavailable" };
+  const worktree = worktreeResult.code === 0 ? worktreeResult.stdout.trim() : "";
+  if (!worktree) {
+    const cwd = git.cwd;
+    if (!cwd) return { reason: "not_repository" };
+    try {
+      const gitPath = join(cwd, ".git");
+      if (!(await stat(gitPath)).isDirectory()) return { reason: "repository_unresolvable" };
+      const canonicalWorktree = await canonicalPath(cwd, cwd);
+      const canonicalGitDir = await canonicalPath(gitPath, canonicalWorktree);
+      return {
+        repository: {
+          worktree: canonicalWorktree,
+          gitDir: canonicalGitDir,
+          commonDir: canonicalGitDir,
+        },
+      };
+    } catch {
+      return { reason: "not_repository" };
+    }
+  }
+
+  const gitDirResult = await invoke(git, ["rev-parse", "--git-dir"]);
+  const commonDirResult = await invoke(git, ["rev-parse", "--git-common-dir"]);
+  if (gitDirResult.error === "unavailable" || commonDirResult.error === "unavailable") {
+    return { reason: "git_unavailable" };
+  }
+  const gitDir = gitDirResult.code === 0 ? gitDirResult.stdout.trim() : "";
+  const commonDir = commonDirResult.code === 0 ? commonDirResult.stdout.trim() : "";
+  if (!gitDir || !commonDir) return { reason: "repository_unresolvable" };
+
   const canonicalWorktree = await canonicalPath(worktree, worktree);
   return {
-    worktree: canonicalWorktree,
-    gitDir: await canonicalPath(gitDir, canonicalWorktree),
-    commonDir: await canonicalPath(commonDir, canonicalWorktree),
+    repository: {
+      worktree: canonicalWorktree,
+      gitDir: await canonicalPath(gitDir, canonicalWorktree),
+      commonDir: await canonicalPath(commonDir, canonicalWorktree),
+    },
   };
 }
 
-async function createSnapshotCommit(git: GitRunner, message: string): Promise<string | null> {
+type SnapshotResult = { hash: string } | { reason: "invalid_head" | "snapshot_failed" };
+
+async function seedSnapshotIndex(
+  git: GitRunner,
+  env: Record<string, string>,
+): Promise<"seeded" | "empty" | "invalid_head" | "failed"> {
+  const headTree = await invoke(git, ["rev-parse", "--verify", "HEAD^{tree}"]);
+  if (headTree.code === 0 && headTree.stdout.trim()) {
+    const seeded = await invoke(git, ["read-tree", headTree.stdout.trim()], { env });
+    return seeded.code === 0 ? "seeded" : "failed";
+  }
+  if (headTree.error === "unavailable") return "failed";
+
+  const symbolicHead = await invoke(git, ["symbolic-ref", "-q", "HEAD"]);
+  if (symbolicHead.code !== 0 || !symbolicHead.stdout.trim()) return "invalid_head";
+  const branchRef = symbolicHead.stdout.trim();
+  const branch = await invoke(git, ["show-ref", "--verify", "--quiet", branchRef]);
+  if (branch.code === 0) return "invalid_head";
+  if (branch.error === "unavailable") return "failed";
+
+  const empty = await invoke(git, ["read-tree", "--empty"], { env });
+  return empty.code === 0 ? "empty" : "failed";
+}
+
+async function createSnapshotCommit(git: GitRunner, message: string): Promise<SnapshotResult> {
   const tempDirectory = await mkdtemp(join(tmpdir(), "omp-undo-redo-index-"));
   const indexPath = join(tempDirectory, "index");
   const env = { GIT_INDEX_FILE: indexPath };
   try {
-    const seeded = await git(["read-tree", "HEAD"], { env });
-    if (seeded.code !== 0) return null;
-    const added = await git(["add", "-A", "--", WORKTREE_PATHSPEC], { env });
-    if (added.code !== 0) return null;
-    const tree = await git(["write-tree"], { env });
-    if (tree.code !== 0) return null;
+    const seeded = await seedSnapshotIndex(git, env);
+    if (seeded === "invalid_head") return { reason: "invalid_head" };
+    if (seeded === "failed") return { reason: "snapshot_failed" };
+    const added = await invoke(git, ["add", "-A", "--", WORKTREE_PATHSPEC], { env });
+    if (added.code !== 0) return { reason: "snapshot_failed" };
+    const tree = await invoke(git, ["write-tree"], { env });
+    if (tree.code !== 0) return { reason: "snapshot_failed" };
     const treeHash = tree.stdout.trim();
-    if (!treeHash) return null;
-    const commit = await git([...GIT_AUTHOR, "commit-tree", treeHash, "-m", message]);
-    if (commit.code !== 0) return null;
+    if (!treeHash) return { reason: "snapshot_failed" };
+    const commit = await invoke(git, [...GIT_AUTHOR, "commit-tree", treeHash, "-m", message]);
+    if (commit.code !== 0) return { reason: "snapshot_failed" };
     const commitHash = commit.stdout.trim();
-    return commitHash || null;
+    return commitHash ? { hash: commitHash } : { reason: "snapshot_failed" };
   } catch {
-    return null;
+    return { reason: "snapshot_failed" };
   } finally {
     await rm(tempDirectory, { recursive: true, force: true });
   }
@@ -97,22 +156,47 @@ export interface RefRelease {
   expectedHash: string;
 }
 
+async function releaseLooseRef(
+  repository: GitRepository,
+  ref: string,
+  expectedHash: string,
+): Promise<boolean> {
+  if (!ref.startsWith("refs/") || ref.includes("..")) return false;
+  const path = join(repository.commonDir, ref);
+  try {
+    if ((await readFile(path, "utf8")).trim() !== expectedHash) return false;
+    await rm(path, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function releaseRefBatch(
   git: GitRunner,
   refs: readonly Pick<RefRelease, "ref" | "expectedHash">[],
+  repository?: GitRepository,
 ): Promise<boolean> {
   if (refs.length === 0) return true;
   const input = refs.map(({ ref, expectedHash }) => `delete ${ref} ${expectedHash}`).join("\n");
+  const args = ["update-ref", "--stdin"];
+  const options = repository
+    ? { env: { GIT_DIR: repository.commonDir }, stdin: `${input}\n` }
+    : { stdin: `${input}\n` };
   try {
-    const result = await git(["update-ref", "--stdin"], { stdin: `${input}\n` });
+    const result = await git(args, options);
     if (result.code === 0) return true;
   } catch {
     // Retry smaller batches below.
   }
-  if (refs.length === 1) return false;
+  if (refs.length === 1) {
+    return repository
+      ? await releaseLooseRef(repository, refs[0].ref, refs[0].expectedHash)
+      : false;
+  }
   const midpoint = Math.ceil(refs.length / 2);
-  const left = await releaseRefBatch(git, refs.slice(0, midpoint));
-  const right = await releaseRefBatch(git, refs.slice(midpoint));
+  const left = await releaseRefBatch(git, refs.slice(0, midpoint), repository);
+  const right = await releaseRefBatch(git, refs.slice(midpoint), repository);
   return left && right;
 }
 
@@ -134,7 +218,7 @@ export async function releaseRefs(
   const results = await Promise.allSettled(
     [...grouped.values()].map(async ({ repository, refs: groupedRefs }) => {
       try {
-        return await releaseRefBatch(gitForRepository(repository), groupedRefs);
+        return await releaseRefBatch(gitForRepository(repository), groupedRefs, repository);
       } catch {
         return false;
       }
@@ -187,23 +271,38 @@ export async function releaseCheckpoint(
 
 export async function releasePendingCheckpoint(
   git: GitRunner,
-  pending: Pick<PendingCheckpoint, "beforeHash" | "beforeRef">,
+  pending: Pick<PendingGitCheckpoint, "repository" | "beforeHash" | "beforeRef">,
 ): Promise<boolean> {
-  return releaseRefBatch(git, [{ ref: pending.beforeRef, expectedHash: pending.beforeHash }]);
+  return releaseRefBatch(
+    git,
+    [{ ref: pending.beforeRef, expectedHash: pending.beforeHash }],
+    pending.repository,
+  );
 }
+
+export type PrepareBeforeTurnResult =
+  | { status: "git"; checkpoint: PendingGitCheckpoint }
+  | { status: "session_only"; reason: FileCheckpointUnavailableReason };
+
+export type FinishAfterTurnResult =
+  | { status: "git"; checkpoint: GitCheckpoint }
+  | { status: "session_only"; reason: FileCheckpointUnavailableReason };
 
 export async function prepareBeforeTurn(
   git: GitRunner,
   sessionId: string,
-): Promise<PendingCheckpoint | null> {
-  const repository = await resolveRepository(git);
-  if (!repository) return null;
-  const head = await output(git, ["rev-parse", "HEAD"]);
-  if (!head) return null;
+): Promise<PrepareBeforeTurnResult> {
+  const resolved = await resolveRepository(git);
+  if ("reason" in resolved) return { status: "session_only", reason: resolved.reason };
 
   const checkpointId = randomUUID();
-  const beforeHash = await createSnapshotCommit(git, "omp-undo-redo: before turn");
-  if (!beforeHash) return null;
+  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn");
+  if (!("hash" in snapshot)) {
+    return {
+      status: "session_only",
+      reason: snapshot.reason === "invalid_head" ? "invalid_head" : "before_snapshot_failed",
+    };
+  }
   const beforeRef = checkpointRefs(sessionId, checkpointId).beforeRef;
   if (
     !(await run(git, [
@@ -211,24 +310,40 @@ export async function prepareBeforeTurn(
       "-m",
       "omp-undo-redo: retain before checkpoint",
       beforeRef,
-      beforeHash,
+      snapshot.hash,
     ]))
   ) {
-    return null;
+    return {
+      status: "session_only",
+      reason: "before_ref_failed",
+    };
   }
-  return { repository, beforeHash, beforeRef, checkpointId, parentLeafId: null };
+  return {
+    status: "git",
+    checkpoint: {
+      kind: "git",
+      repository: resolved.repository,
+      beforeHash: snapshot.hash,
+      beforeRef,
+      checkpointId,
+      parentLeafId: null,
+    },
+  };
 }
 
 export async function finishAfterTurn(
   git: GitRunner,
-  before: Pick<PendingCheckpoint, "repository" | "beforeHash" | "beforeRef" | "checkpointId">,
+  before: Pick<PendingGitCheckpoint, "repository" | "beforeHash" | "beforeRef" | "checkpointId">,
   parentLeafId: string | null,
   leafId: string | null,
-): Promise<GitCheckpoint | null> {
-  const afterHash = await createSnapshotCommit(git, "omp-undo-redo: after turn");
-  if (!afterHash) {
+): Promise<FinishAfterTurnResult> {
+  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
+  if (!("hash" in snapshot)) {
     await releasePendingCheckpoint(git, before);
-    return null;
+    return {
+      status: "session_only",
+      reason: snapshot.reason === "invalid_head" ? "invalid_head" : "after_snapshot_failed",
+    };
   }
   const afterRef = before.beforeRef.replace(/\/before$/, "/after");
   if (
@@ -237,20 +352,24 @@ export async function finishAfterTurn(
       "-m",
       "omp-undo-redo: retain after checkpoint",
       afterRef,
-      afterHash,
+      snapshot.hash,
     ]))
   ) {
     await releasePendingCheckpoint(git, before);
-    return null;
+    return { status: "session_only", reason: "after_ref_failed" };
   }
   return {
-    repository: before.repository,
-    beforeHash: before.beforeHash,
-    beforeRef: before.beforeRef,
-    afterHash,
-    afterRef,
-    parentLeafId,
-    leafId,
+    status: "git",
+    checkpoint: {
+      kind: "git",
+      repository: before.repository,
+      beforeHash: before.beforeHash,
+      beforeRef: before.beforeRef,
+      afterHash: snapshot.hash,
+      afterRef,
+      parentLeafId,
+      leafId,
+    },
   };
 }
 

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -5,12 +5,13 @@ import type {
   GitRunnerFactory,
   NavigationPort,
   NavigationResult,
+  SessionOnlyCheckpoint,
+  TreeNavigationResult,
+  TurnCheckpoint,
 } from "./types.js";
 import { applyCheckpoint, releaseCheckpoints } from "./checkpoints.js";
 
-export type NavigationOutcome = "moved" | "empty" | "cancelled" | "git_failed" | "rollback_failed";
-
-type GitFailure = "conflict" | "failed" | "rollback_failed";
+export type NavigationOutcome = NavigationResult;
 
 type ExpectedTreeNavigation = {
   oldLeafId: string | null;
@@ -18,11 +19,10 @@ type ExpectedTreeNavigation = {
 };
 
 export class SessionNavigation {
-  private checkpoints: GitCheckpoint[] = [];
+  private checkpoints: TurnCheckpoint[] = [];
   private currentIndex = -1;
   private navigateTree: NavigationPort["navigateTree"] = async () => ({ cancelled: true });
   private expectedTreeNavigation: ExpectedTreeNavigation | null = null;
-  private lastGitFailure: GitFailure | null = null;
   private readonly gitForRepository: GitRunnerFactory;
 
   constructor(
@@ -40,7 +40,7 @@ export class SessionNavigation {
     this.navigateTree = navigateTree;
   }
 
-  private async navigateTo(targetId: string): Promise<NavigationResult> {
+  private async navigateTo(targetId: string): Promise<TreeNavigationResult> {
     this.expectedTreeNavigation = {
       oldLeafId: this.port.getLeafId(),
       newLeafId: targetId,
@@ -69,87 +69,88 @@ export class SessionNavigation {
 
   async invalidateRedo(): Promise<void> {
     const discarded = this.checkpoints.splice(this.currentIndex + 1);
-    await releaseCheckpoints(this.gitForRepository, discarded);
+    await releaseCheckpoints(
+      this.gitForRepository,
+      discarded.filter((checkpoint): checkpoint is GitCheckpoint => checkpoint.kind === "git"),
+    );
   }
 
-  getLastGitFailure(): GitFailure | null {
-    return this.lastGitFailure;
-  }
-
-  async recordTurnEnd(checkpoint: GitCheckpoint): Promise<void> {
+  async recordTurnEnd(checkpoint: TurnCheckpoint): Promise<void> {
     const discarded = this.checkpoints.splice(
       this.currentIndex + 1,
       this.checkpoints.length - this.currentIndex - 1,
     );
     this.checkpoints.push(checkpoint);
     this.currentIndex = this.checkpoints.length - 1;
-    await releaseCheckpoints(this.gitForRepository, discarded);
+    await releaseCheckpoints(
+      this.gitForRepository,
+      discarded.filter((entry): entry is GitCheckpoint => entry.kind === "git"),
+    );
   }
 
   async dispose(): Promise<void> {
     const checkpoints = this.checkpoints;
     this.checkpoints = [];
     this.currentIndex = -1;
-    await releaseCheckpoints(this.gitForRepository, checkpoints);
+    await releaseCheckpoints(
+      this.gitForRepository,
+      checkpoints.filter((checkpoint): checkpoint is GitCheckpoint => checkpoint.kind === "git"),
+    );
   }
 
-  async undo(): Promise<NavigationOutcome> {
-    this.lastGitFailure = null;
-    if (this.currentIndex < 0) return "empty";
+  private async navigateSession(targetId: string | null): Promise<boolean> {
+    if (!targetId) return true;
+    const result = await this.navigateTo(targetId);
+    return !result.cancelled;
+  }
+
+  private sessionOnlyResult(checkpoint: SessionOnlyCheckpoint): NavigationResult {
+    return { status: "moved", files: "unavailable", reason: checkpoint.reason };
+  }
+
+  async undo(): Promise<NavigationResult> {
+    if (this.currentIndex < 0) return { status: "empty" };
     const checkpoint = this.checkpoints[this.currentIndex];
+    if (checkpoint.kind === "session") {
+      if (!(await this.navigateSession(checkpoint.parentLeafId))) return { status: "cancelled" };
+      this.currentIndex--;
+      return this.sessionOnlyResult(checkpoint);
+    }
+
     const git = this.gitForRepository(checkpoint.repository);
     const applied = await applyCheckpoint(git, checkpoint.afterHash, checkpoint.beforeHash);
     if (applied !== "applied") {
-      this.lastGitFailure = applied;
-      return "git_failed";
+      return { status: "git_failed", failure: applied === "conflict" ? "conflict" : "failed" };
     }
-    if (checkpoint.parentLeafId) {
-      let result: NavigationResult;
-      try {
-        result = await this.navigateTo(checkpoint.parentLeafId);
-      } catch {
-        result = { cancelled: true };
-      }
-      if (result.cancelled) {
-        const compensated = await applyCheckpoint(git, checkpoint.beforeHash, checkpoint.afterHash);
-        if (compensated !== "applied") {
-          this.lastGitFailure = "rollback_failed";
-          return "rollback_failed";
-        }
-        return "cancelled";
-      }
+    if (!(await this.navigateSession(checkpoint.parentLeafId))) {
+      const compensated = await applyCheckpoint(git, checkpoint.beforeHash, checkpoint.afterHash);
+      if (compensated !== "applied") return { status: "rollback_failed" };
+      return { status: "cancelled" };
     }
     this.currentIndex--;
-    return "moved";
+    return { status: "moved", files: "restored" };
   }
 
-  async redo(): Promise<NavigationOutcome> {
-    this.lastGitFailure = null;
-    if (this.currentIndex >= this.checkpoints.length - 1) return "empty";
+  async redo(): Promise<NavigationResult> {
+    if (this.currentIndex >= this.checkpoints.length - 1) return { status: "empty" };
     const checkpoint = this.checkpoints[this.currentIndex + 1];
+    if (checkpoint.kind === "session") {
+      if (!(await this.navigateSession(checkpoint.leafId))) return { status: "cancelled" };
+      this.currentIndex++;
+      return this.sessionOnlyResult(checkpoint);
+    }
+
     const git = this.gitForRepository(checkpoint.repository);
     const applied = await applyCheckpoint(git, checkpoint.beforeHash, checkpoint.afterHash);
     if (applied !== "applied") {
-      this.lastGitFailure = applied;
-      return "git_failed";
+      return { status: "git_failed", failure: applied === "conflict" ? "conflict" : "failed" };
     }
-    if (checkpoint.leafId) {
-      let result: NavigationResult;
-      try {
-        result = await this.navigateTo(checkpoint.leafId);
-      } catch {
-        result = { cancelled: true };
-      }
-      if (result.cancelled) {
-        const compensated = await applyCheckpoint(git, checkpoint.afterHash, checkpoint.beforeHash);
-        if (compensated !== "applied") {
-          this.lastGitFailure = "rollback_failed";
-          return "rollback_failed";
-        }
-        return "cancelled";
-      }
+    if (!(await this.navigateSession(checkpoint.leafId))) {
+      const compensated = await applyCheckpoint(git, checkpoint.afterHash, checkpoint.beforeHash);
+      if (compensated !== "applied") return { status: "rollback_failed" };
+      return { status: "cancelled" };
     }
     this.currentIndex++;
-    return "moved";
+    return { status: "moved", files: "restored" };
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,12 +11,34 @@ export interface SessionReader {
   getEntry(id: string): SessionEntryLike | undefined;
 }
 
-export interface NavigationResult {
+export type FileCheckpointUnavailableReason =
+  | "git_unavailable"
+  | "not_repository"
+  | "repository_unresolvable"
+  | "invalid_head"
+  | "before_snapshot_failed"
+  | "before_ref_failed"
+  | "after_snapshot_failed"
+  | "after_ref_failed";
+
+export type TreeNavigationResult = {
   cancelled: boolean;
-}
+};
+
+export type NavigationResult =
+  | { status: "moved"; files: "restored" }
+  | {
+      status: "moved";
+      files: "unavailable";
+      reason: FileCheckpointUnavailableReason;
+    }
+  | { status: "empty" }
+  | { status: "cancelled" }
+  | { status: "git_failed"; failure: "conflict" | "failed" }
+  | { status: "rollback_failed" };
 
 export interface NavigationPort extends SessionReader {
-  navigateTree(targetId: string): Promise<NavigationResult>;
+  navigateTree(targetId: string): Promise<TreeNavigationResult>;
 }
 
 export interface GitRunOptions {
@@ -24,10 +46,17 @@ export interface GitRunOptions {
   stdin?: string;
 }
 
-export type GitRunner = (
+export type GitRunner = ((
   args: string[],
   options?: GitRunOptions,
-) => Promise<{ stdout: string; stderr: string; code: number }>;
+) => Promise<{
+  stdout: string;
+  stderr: string;
+  code: number;
+  error?: "unavailable";
+}>) & {
+  cwd?: string;
+};
 
 export interface GitRepository {
   worktree: string;
@@ -36,6 +65,7 @@ export interface GitRepository {
 }
 
 export interface GitCheckpoint {
+  kind: "git";
   repository: GitRepository;
   beforeHash: string;
   beforeRef: string;
@@ -45,12 +75,30 @@ export interface GitCheckpoint {
   leafId: string | null;
 }
 
-export interface PendingCheckpoint {
+export interface SessionOnlyCheckpoint {
+  kind: "session";
+  reason: FileCheckpointUnavailableReason;
+  parentLeafId: string | null;
+  leafId: string | null;
+}
+
+export type TurnCheckpoint = GitCheckpoint | SessionOnlyCheckpoint;
+
+export interface PendingGitCheckpoint {
+  kind: "git";
   repository: GitRepository;
   beforeHash: string;
   beforeRef: string;
   checkpointId: string;
   parentLeafId: string | null;
 }
+
+export interface PendingSessionCheckpoint {
+  kind: "session";
+  reason: FileCheckpointUnavailableReason;
+  parentLeafId: string | null;
+}
+
+export type PendingTurnCheckpoint = PendingGitCheckpoint | PendingSessionCheckpoint;
 
 export type GitRunnerFactory = (repository: GitRepository) => GitRunner;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   releaseCheckpoint,
   releasePendingCheckpoint,
 } from "./core/checkpoints.js";
-import type { GitRunner, PendingCheckpoint } from "./core/types.js";
+import type { GitRunner, PendingTurnCheckpoint, SessionOnlyCheckpoint } from "./core/types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -39,12 +39,13 @@ type AnyContext = {
 };
 
 function createGitRunner(cwd: string): GitRunner {
-  return async (args, options) => {
+  const runner: GitRunner = async (args, options) => {
     if (options?.stdin !== undefined) {
       const { promise, resolve } = promiseWithResolvers<{
         stdout: string;
         stderr: string;
         code: number;
+        error?: "unavailable";
       }>();
       const child = spawn("git", args, {
         cwd,
@@ -69,6 +70,7 @@ function createGitRunner(cwd: string): GitRunner {
           stdout,
           stderr: `${stderr}${error.message}`,
           code: 1,
+          error: "unavailable",
         });
       });
       child.once("close", (code) => {
@@ -96,9 +98,12 @@ function createGitRunner(cwd: string): GitRunner {
         stdout: failure.stdout ?? "",
         stderr: failure.stderr ?? "",
         code: typeof failure.code === "number" ? failure.code : 1,
+        ...(typeof failure.code === "number" ? {} : { error: "unavailable" as const }),
       };
     }
   };
+  runner.cwd = cwd;
+  return runner;
 }
 
 function createNavigation(ctx: AnyContext): SessionNavigation {
@@ -116,7 +121,7 @@ function createNavigation(ctx: AnyContext): SessionNavigation {
 
 export default function ompUndoRedo(pi: ExtensionAPI): void {
   const navigations = new Map<string, SessionNavigation>();
-  const pending = new Map<string, PendingCheckpoint>();
+  const pending = new Map<string, PendingTurnCheckpoint>();
   const activeOperations = new Set<Promise<void>>();
   let closing = false;
   let shutdownPromise: Promise<void> | null = null;
@@ -139,7 +144,8 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     return tracked;
   }
 
-  async function releasePending(pendingCheckpoint: PendingCheckpoint): Promise<void> {
+  async function releasePending(pendingCheckpoint: PendingTurnCheckpoint): Promise<void> {
+    if (pendingCheckpoint.kind !== "git") return;
     await releasePendingCheckpoint(
       createGitRunner(pendingCheckpoint.repository.worktree),
       pendingCheckpoint,
@@ -148,7 +154,7 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
 
   async function disposeDetached(
     detachedNavigations: readonly SessionNavigation[],
-    detachedPending: readonly PendingCheckpoint[],
+    detachedPending: readonly PendingTurnCheckpoint[],
   ): Promise<void> {
     await Promise.allSettled([
       ...detachedNavigations.map((navigation) => navigation.dispose()),
@@ -245,12 +251,13 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
       const oldPending = pending.get(sessionId);
       pending.delete(sessionId);
       if (oldPending) await releasePending(oldPending);
-      const before = await prepareBeforeTurn(createGitRunner(typed.cwd), sessionId);
-      if (!before) return;
-      const checkpoint = {
-        ...before,
-        parentLeafId: typed.sessionManager.getLeafId(),
-      };
+
+      const prepared = await prepareBeforeTurn(createGitRunner(typed.cwd), sessionId);
+      const parentLeafId = typed.sessionManager.getLeafId();
+      const checkpoint: PendingTurnCheckpoint =
+        prepared.status === "git"
+          ? { ...prepared.checkpoint, parentLeafId }
+          : { kind: "session", reason: prepared.reason, parentLeafId };
       if (closing) {
         await releasePending(checkpoint);
         return;
@@ -270,20 +277,45 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
         await releasePending(before);
         return;
       }
-      const checkpoint = await finishAfterTurn(
-        createGitRunner(before.repository.worktree),
-        before,
-        before.parentLeafId,
-        typed.sessionManager.getLeafId(),
-      );
-      if (!checkpoint) return;
-      if (closing) {
-        await releaseCheckpoint(createGitRunner(checkpoint.repository.worktree), checkpoint);
-        return;
+
+      let completed: SessionOnlyCheckpoint | undefined;
+      if (before.kind === "session") {
+        completed = {
+          kind: "session",
+          reason: before.reason,
+          parentLeafId: before.parentLeafId,
+          leafId: typed.sessionManager.getLeafId(),
+        };
+      } else {
+        const result = await finishAfterTurn(
+          createGitRunner(before.repository.worktree),
+          before,
+          before.parentLeafId,
+          typed.sessionManager.getLeafId(),
+        );
+        if (result.status === "git") {
+          if (closing) {
+            await releaseCheckpoint(
+              createGitRunner(result.checkpoint.repository.worktree),
+              result.checkpoint,
+            );
+            return;
+          }
+          const nav = navigations.get(sessionId) ?? createNavigation(typed);
+          navigations.set(sessionId, nav);
+          await nav.recordTurnEnd(result.checkpoint);
+          return;
+        }
+        completed = {
+          kind: "session",
+          reason: result.reason,
+          parentLeafId: before.parentLeafId,
+          leafId: typed.sessionManager.getLeafId(),
+        };
       }
       const nav = navigations.get(sessionId) ?? createNavigation(typed);
       navigations.set(sessionId, nav);
-      await nav.recordTurnEnd(checkpoint);
+      await nav.recordTurnEnd(completed);
     }),
   );
 

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -30,6 +30,7 @@ import type {
   GitCheckpoint,
   GitRunner,
   NavigationPort,
+  PendingGitCheckpoint,
   SessionEntryLike,
   SessionReader,
 } from "../src/core/types.js";
@@ -61,7 +62,7 @@ const entries: SessionEntryLike[] = [
 ];
 
 function gitRunner(cwd: string): GitRunner {
-  return async (args, options) => {
+  const runner: GitRunner = async (args, options) => {
     if (options?.stdin !== undefined) {
       const child = spawn("git", args, {
         cwd,
@@ -102,6 +103,8 @@ function gitRunner(cwd: string): GitRunner {
       };
     }
   };
+  runner.cwd = cwd;
+  return runner;
 }
 
 async function makeRepo(): Promise<{ cwd: string; git: GitRunner }> {
@@ -147,12 +150,27 @@ async function indexState(
   return { tree: await text(git, ["write-tree"]), raw: await readFile(path) };
 }
 
+function pendingCheckpoint(
+  result: Awaited<ReturnType<typeof prepareBeforeTurn>>,
+): PendingGitCheckpoint {
+  expect(result.status).toBe("git");
+  if (result.status !== "git") throw new Error(`Expected Git checkpoint, got ${result.reason}`);
+  return result.checkpoint;
+}
+
+function completedCheckpoint(result: Awaited<ReturnType<typeof finishAfterTurn>>): GitCheckpoint {
+  expect(result.status).toBe("git");
+  if (result.status !== "git") throw new Error(`Expected Git checkpoint, got ${result.reason}`);
+  return result.checkpoint;
+}
+
 function checkpointWithRepository(
   beforeHash: string,
   afterHash: string,
   repository: GitCheckpoint["repository"],
 ): GitCheckpoint {
   return {
+    kind: "git",
     repository,
     beforeHash,
     beforeRef: "refs/omp-undo-redo/test/before",
@@ -188,7 +206,7 @@ describe("history-safe Git checkpoints", () => {
     try {
       await initializeBranch(git, cwd);
       const beforeIndex = await indexState(git, cwd);
-      const before = await prepareBeforeTurn(git, "intervening-commit");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "intervening-commit"));
       expect(before).not.toBeNull();
       if (!before) return;
       expect(await indexState(git, cwd)).toEqual(beforeIndex);
@@ -200,7 +218,7 @@ describe("history-safe Git checkpoints", () => {
       const branchTip = await text(git, ["rev-parse", "refs/heads/A"]);
       const afterAgentIndex = await indexState(git, cwd);
       await writeFile(join(cwd, "turn.txt"), "uncommitted turn change\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
 
@@ -233,10 +251,10 @@ describe("history-safe Git checkpoints", () => {
       const beforeIndex = await indexState(git, cwd);
       const beforeContents = await readFile(join(cwd, "tracked.txt"), "utf8");
 
-      const pending = await prepareBeforeTurn(git, "empty-turn");
+      const pending = pendingCheckpoint(await prepareBeforeTurn(git, "empty-turn"));
       expect(pending).not.toBeNull();
       if (!pending) return;
-      const checkpoint = await finishAfterTurn(git, pending, "u1", "a1");
+      const checkpoint = completedCheckpoint(await finishAfterTurn(git, pending, "u1", "a1"));
       expect(checkpoint).not.toBeNull();
       if (!checkpoint) return;
       expect(await text(git, ["rev-parse", `${checkpoint.beforeHash}^{tree}`])).toBe(
@@ -256,12 +274,10 @@ describe("history-safe Git checkpoints", () => {
       const navigation = new SessionNavigation(navigationPort, git);
       await navigation.recordTurnEnd(checkpoint);
 
-      expect(await navigation.undo()).toBe("moved");
+      expect((await navigation.undo()).status).toBe("moved");
       expect(navigated).toEqual(["u1"]);
-      expect(navigation.getLastGitFailure()).toBeNull();
-      expect(await navigation.redo()).toBe("moved");
+      expect((await navigation.redo()).status).toBe("moved");
       expect(navigated).toEqual(["u1", "a1"]);
-      expect(navigation.getLastGitFailure()).toBeNull();
 
       expect(await text(git, ["rev-parse", "HEAD"])).toBe(beforeHead);
       expect(await branchRefs(git)).toBe(beforeRefs);
@@ -285,11 +301,11 @@ describe("history-safe Git checkpoints", () => {
       const beforeIndex = await indexState(git, cwd);
       const beforeContents = await readFile(join(cwd, "tracked.txt"), "utf8");
 
-      const pending = await prepareBeforeTurn(git, "ignored-turn");
+      const pending = pendingCheckpoint(await prepareBeforeTurn(git, "ignored-turn"));
       expect(pending).not.toBeNull();
       if (!pending) return;
       await writeFile(ignoredPath, "ignored after turn\n");
-      const checkpoint = await finishAfterTurn(git, pending, "u1", "a1");
+      const checkpoint = completedCheckpoint(await finishAfterTurn(git, pending, "u1", "a1"));
       expect(checkpoint).not.toBeNull();
       if (!checkpoint) return;
       expect(await text(git, ["rev-parse", `${checkpoint.beforeHash}^{tree}`])).toBe(
@@ -309,12 +325,10 @@ describe("history-safe Git checkpoints", () => {
       const navigation = new SessionNavigation(navigationPort, git);
       await navigation.recordTurnEnd(checkpoint);
 
-      expect(await navigation.undo()).toBe("moved");
+      expect((await navigation.undo()).status).toBe("moved");
       expect(navigated).toEqual(["u1"]);
-      expect(navigation.getLastGitFailure()).toBeNull();
-      expect(await navigation.redo()).toBe("moved");
+      expect((await navigation.redo()).status).toBe("moved");
       expect(navigated).toEqual(["u1", "a1"]);
-      expect(navigation.getLastGitFailure()).toBeNull();
 
       expect(await text(git, ["rev-parse", "HEAD"])).toBe(beforeHead);
       expect(await branchRefs(git)).toBe(beforeRefs);
@@ -350,11 +364,11 @@ describe("history-safe Git checkpoints", () => {
       const head = await text(git, ["rev-parse", "HEAD"]);
       const refs = await branchRefs(git);
 
-      const before = await prepareBeforeTurn(nestedGit, "subdirectory-scope");
+      const before = pendingCheckpoint(await prepareBeforeTurn(nestedGit, "subdirectory-scope"));
       expect(before).not.toBeNull();
       if (!before) return;
       await writeFile(join(nested, "inside.txt"), "inside after turn\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
 
@@ -401,12 +415,10 @@ describe("history-safe Git checkpoints", () => {
       await git(["add", "."]);
       await git(["commit", "-qm", "tree equivalence fixtures"]);
 
-      const rootCheckpoint = await prepareBeforeTurn(git, "root-tree");
+      const rootCheckpoint = pendingCheckpoint(await prepareBeforeTurn(git, "root-tree"));
       expect(rootCheckpoint).not.toBeNull();
       if (!rootCheckpoint) return;
-      const nestedCheckpoint = await prepareBeforeTurn(nestedGit, "nested-tree");
-      expect(nestedCheckpoint).not.toBeNull();
-      if (!nestedCheckpoint) return;
+      const nestedCheckpoint = pendingCheckpoint(await prepareBeforeTurn(nestedGit, "nested-tree"));
 
       expect(await text(git, ["rev-parse", `${rootCheckpoint.beforeHash}^{tree}`])).toBe(
         await text(git, ["rev-parse", `${nestedCheckpoint.beforeHash}^{tree}`]),
@@ -420,7 +432,7 @@ describe("history-safe Git checkpoints", () => {
     const { cwd, git } = await makeRepo();
     try {
       await initializeBranch(git, cwd);
-      const before = await prepareBeforeTurn(git, "branch-switch");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "branch-switch"));
       expect(before).not.toBeNull();
       if (!before) return;
       await git(["switch", "-c", "B"]);
@@ -428,7 +440,7 @@ describe("history-safe Git checkpoints", () => {
       const branchBTip = await text(git, ["rev-parse", "B"]);
       const refsAfterSwitch = await branchRefs(git);
       await writeFile(join(cwd, "tracked.txt"), "branch B after\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
 
@@ -471,7 +483,7 @@ describe("history-safe Git checkpoints", () => {
 
       const saved = await indexState(git, cwd);
       const beforeStatus = await text(git, ["status", "--porcelain=v2"]);
-      const before = await prepareBeforeTurn(git, "index-preservation");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "index-preservation"));
       expect(before).not.toBeNull();
       if (!before) return;
       expect(await indexState(git, cwd)).toEqual(saved);
@@ -479,7 +491,7 @@ describe("history-safe Git checkpoints", () => {
 
       await writeFile(join(cwd, "staged.txt"), "after turn\n");
       await writeFile(join(cwd, "after-only.txt"), "after only\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
       expect(await indexState(git, cwd)).toEqual(saved);
@@ -499,12 +511,12 @@ describe("history-safe Git checkpoints", () => {
     try {
       await initializeBranch(git, cwd);
       const refs = await branchRefs(git);
-      const before = await prepareBeforeTurn(git, "ref-invariant");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "ref-invariant"));
       expect(before).not.toBeNull();
       if (!before) return;
       expect(await branchRefs(git)).toBe(refs);
       await writeFile(join(cwd, "tracked.txt"), "changed\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
       expect(await branchRefs(git)).toBe(refs);
@@ -545,7 +557,7 @@ describe("history-safe Git checkpoints", () => {
         symlinkMode && symlinkConfig.code === 0 && symlinkConfig.stdout.trim() === "true";
       await writeFile(join(cwd, "before-only.txt"), "before only\n");
       const executableBefore = (await stat(join(cwd, "executable.sh"))).mode & 0o111;
-      const before = await prepareBeforeTurn(git, "restoration-matrix");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "restoration-matrix"));
       expect(before).not.toBeNull();
       if (!before) return;
       await rm(join(cwd, "old name.txt"));
@@ -558,7 +570,7 @@ describe("history-safe Git checkpoints", () => {
         await writeFile(join(cwd, "link to old.txt"), "regular file\n");
       }
       await writeFile(join(cwd, "after-only Ω.txt"), "after only\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
 
@@ -592,11 +604,11 @@ describe("history-safe Git checkpoints", () => {
     const { cwd, git } = await makeRepo();
     try {
       await initializeBranch(git, cwd);
-      const before = await prepareBeforeTurn(git, "conflict");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "conflict"));
       expect(before).not.toBeNull();
       if (!before) return;
       await writeFile(join(cwd, "tracked.txt"), "after\n");
-      const after = await finishAfterTurn(git, before, null, null);
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(after).not.toBeNull();
       if (!after) return;
       const checkpoint = checkpointWithRepository(
@@ -617,12 +629,11 @@ describe("history-safe Git checkpoints", () => {
       const navigation = new SessionNavigation(navigationPort, git);
       await navigation.recordTurnEnd(checkpoint);
 
-      expect(await navigation.undo()).toBe("git_failed");
-      expect(navigation.getLastGitFailure()).toBe("conflict");
+      expect(await navigation.undo()).toEqual({ status: "git_failed", failure: "conflict" });
       expect(await readFile(join(cwd, "tracked.txt"))).toEqual(savedContent);
       expect(await indexState(git, cwd)).toEqual(savedIndex);
       expect(await branchRefs(git)).toBe(savedRefs);
-      expect(await navigation.undo()).toBe("git_failed");
+      expect((await navigation.undo()).status).toBe("git_failed");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -639,12 +650,12 @@ describe("history-safe Git checkpoints", () => {
       await git(["reset", "--mixed", "HEAD^"]);
       await writeFile(join(cwd, "untracked.txt"), "before-only\n");
 
-      const before = await prepareBeforeTurn(git, "gc");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "gc"));
       expect(before).not.toBeNull();
       if (!before) return;
       await writeFile(join(cwd, "tracked.txt"), "after\n");
       await writeFile(join(cwd, "untracked.txt"), "after-only\n");
-      const checkpoint = await finishAfterTurn(git, before, null, null);
+      const checkpoint = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(checkpoint).not.toBeNull();
       if (!checkpoint) return;
       await git(["reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"]);
@@ -664,11 +675,11 @@ describe("history-safe Git checkpoints", () => {
     const { cwd, git } = await makeRepo();
     try {
       await initializeBranch(git, cwd);
-      const before = await prepareBeforeTurn(git, "batch");
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "batch"));
       expect(before).not.toBeNull();
       if (!before) return;
       await writeFile(join(cwd, "tracked.txt"), "after\n");
-      const checkpoint = await finishAfterTurn(git, before, null, null);
+      const checkpoint = completedCheckpoint(await finishAfterTurn(git, before, null, null));
       expect(checkpoint).not.toBeNull();
       if (!checkpoint) return;
       await git(["update-ref", "refs/keep", "HEAD"]);
@@ -698,6 +709,79 @@ describe("history-safe Git checkpoints", () => {
       expect((await git(["rev-parse", "refs/keep"])).stdout.trim()).toBe(
         (await git(["rev-parse", "HEAD"])).stdout.trim(),
       );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("supports full checkpoints in an unborn repository", async () => {
+    const { cwd, git } = await makeRepo();
+    try {
+      await writeFile(join(cwd, "before.txt"), "before\n");
+      const prepared = await prepareBeforeTurn(git, "unborn");
+      expect(prepared.status).toBe("git");
+      if (prepared.status !== "git") return;
+
+      await rm(join(cwd, "before.txt"));
+      await writeFile(join(cwd, "after.txt"), "after\n");
+      const finished = await finishAfterTurn(git, prepared.checkpoint, "u1", "a1");
+      expect(finished.status).toBe("git");
+      if (finished.status !== "git") return;
+
+      expect(
+        await applyCheckpoint(git, finished.checkpoint.afterHash, finished.checkpoint.beforeHash),
+      ).toBe("applied");
+      await expect(readFile(join(cwd, "before.txt"), "utf8")).resolves.toBe("before\n");
+      await expect(readFile(join(cwd, "after.txt"))).rejects.toThrow();
+
+      expect(
+        await applyCheckpoint(git, finished.checkpoint.beforeHash, finished.checkpoint.afterHash),
+      ).toBe("applied");
+      await expect(readFile(join(cwd, "after.txt"), "utf8")).resolves.toBe("after\n");
+      expect((await git(["rev-parse", "HEAD"])).code).not.toBe(0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("creates valid empty snapshots in an unborn repository", async () => {
+    const { cwd, git } = await makeRepo();
+    try {
+      const prepared = await prepareBeforeTurn(git, "empty-unborn");
+      expect(prepared.status).toBe("git");
+      if (prepared.status !== "git") return;
+      const finished = await finishAfterTurn(git, prepared.checkpoint, null, null);
+      expect(finished.status).toBe("git");
+      if (finished.status !== "git") return;
+      expect(await text(git, ["rev-parse", `${finished.checkpoint.beforeHash}^{tree}`])).toMatch(
+        /^[0-9a-f]{40}$/,
+      );
+      expect(await text(git, ["rev-parse", `${finished.checkpoint.afterHash}^{tree}`])).toMatch(
+        /^[0-9a-f]{40}$/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a stable reason when the cwd is not a repository", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-non-repo-"));
+    try {
+      const result = await prepareBeforeTurn(gitRunner(cwd), "non-repo");
+      expect(result).toEqual({ status: "session_only", reason: "not_repository" });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies a malformed HEAD instead of treating it as unborn", async () => {
+    const { cwd, git } = await makeRepo();
+    try {
+      await initializeBranch(git, cwd);
+      await writeFile(join(cwd, ".git", "HEAD"), "not-a-head\n");
+      expect(await prepareBeforeTurn(git, "invalid-head")).toEqual({
+        status: "session_only",
+        reason: "invalid_head",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/test/command-behavior.test.ts
+++ b/test/command-behavior.test.ts
@@ -1,6 +1,12 @@
 import { SessionNavigation } from "../src/core/session-navigation.js";
 import { describe, expect, it } from "vitest";
-import type { GitCheckpoint, GitRepository, GitRunner, NavigationPort } from "../src/core/types.js";
+import type {
+  GitCheckpoint,
+  GitRepository,
+  GitRunner,
+  NavigationPort,
+  SessionOnlyCheckpoint,
+} from "../src/core/types.js";
 
 function mockGit(): GitRunner {
   return async () => ({ stdout: "", stderr: "", code: 0 });
@@ -58,11 +64,21 @@ function checkpoint(parentLeafId: string | null, leafId: string): GitCheckpoint 
     commonDir: ".git",
   };
   return {
+    kind: "git",
     repository,
     beforeHash: `before-${leafId}`,
     beforeRef: `refs/omp-undo-redo/test/${leafId}/before`,
     afterHash: `after-${leafId}`,
     afterRef: `refs/omp-undo-redo/test/${leafId}/after`,
+    parentLeafId,
+    leafId,
+  };
+}
+
+function sessionCheckpoint(parentLeafId: string | null, leafId: string): SessionOnlyCheckpoint {
+  return {
+    kind: "session",
+    reason: "not_repository",
     parentLeafId,
     leafId,
   };
@@ -81,17 +97,17 @@ describe("session navigation", () => {
     navigation.recordTurnEnd(checkpoint("u1", "a1"));
     navigation.recordTurnEnd(checkpoint("u2", "a2"));
 
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
     expect(session.leaf).toBe("u2");
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
     expect(session.leaf).toBe("u1");
-    expect(await navigation.undo()).toBe("empty");
+    expect((await navigation.undo()).status).toBe("empty");
 
-    expect(await navigation.redo()).toBe("moved");
+    expect((await navigation.redo()).status).toBe("moved");
     expect(session.leaf).toBe("a1");
-    expect(await navigation.redo()).toBe("moved");
+    expect((await navigation.redo()).status).toBe("moved");
     expect(session.leaf).toBe("a2");
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.redo()).status).toBe("empty");
   });
 
   it("preserves redo for matching internal tree navigation", async () => {
@@ -107,9 +123,9 @@ describe("session navigation", () => {
     await navigation.recordTurnEnd(checkpoint("u1", "a1"));
     await navigation.recordTurnEnd(checkpoint("u2", "a2"));
 
-    expect(await navigation.undo()).toBe("moved");
-    expect(await navigation.redo()).toBe("moved");
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.undo()).status).toBe("moved");
+    expect((await navigation.redo()).status).toBe("moved");
+    expect((await navigation.redo()).status).toBe("empty");
   });
 
   it("invalidates only redo after unrelated tree navigation", async () => {
@@ -117,13 +133,13 @@ describe("session navigation", () => {
     const navigation = makeNavigation(session);
     await navigation.recordTurnEnd(checkpoint("u1", "a1"));
     await navigation.recordTurnEnd(checkpoint("u2", "a2"));
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
 
     await navigation.handleSessionTreeNavigation("u2", "other");
 
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.redo()).status).toBe("empty");
     expect(session.navigateCalls).toEqual(["u2"]);
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
     expect(session.navigateCalls).toEqual(["u2", "u1"]);
   });
 
@@ -132,11 +148,11 @@ describe("session navigation", () => {
     const navigation = makeNavigation(session);
     await navigation.recordTurnEnd(checkpoint("u1", "a1"));
     await navigation.recordTurnEnd(checkpoint("u2", "a2"));
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
 
     await navigation.handleSessionTreeNavigation("u2", "u2");
 
-    expect(await navigation.redo()).toBe("moved");
+    expect((await navigation.redo()).status).toBe("moved");
   });
 
   it("clears an expected transition after cancelled navigation", async () => {
@@ -144,13 +160,13 @@ describe("session navigation", () => {
     const navigation = makeNavigation(session);
     await navigation.recordTurnEnd(checkpoint("u1", "a1"));
     await navigation.recordTurnEnd(checkpoint("u2", "a2"));
-    expect(await navigation.undo()).toBe("moved");
+    expect((await navigation.undo()).status).toBe("moved");
     navigation.setNavigateTree(async () => ({ cancelled: true }));
 
-    expect(await navigation.redo()).toBe("cancelled");
+    expect((await navigation.redo()).status).toBe("cancelled");
     await navigation.handleSessionTreeNavigation("u2", "a2");
 
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.redo()).status).toBe("empty");
   });
 
   it("clears forward checkpoints on a new branch", async () => {
@@ -160,7 +176,7 @@ describe("session navigation", () => {
     navigation.recordTurnEnd(checkpoint("u2", "a2"));
     await navigation.undo();
     navigation.recordTurnEnd(checkpoint("u1", "new-branch"));
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.redo()).status).toBe("empty");
   });
 
   it("rejects cancelled navigation", async () => {
@@ -168,8 +184,8 @@ describe("session navigation", () => {
     session.navigateTree = async () => ({ cancelled: true });
     const navigation = makeNavigation(session);
     navigation.recordTurnEnd(checkpoint("u1", "a1"));
-    expect(await navigation.undo()).toBe("cancelled");
-    expect(await navigation.redo()).toBe("empty");
+    expect((await navigation.undo()).status).toBe("cancelled");
+    expect((await navigation.redo()).status).toBe("empty");
   });
 
   it("reports Git restore failures", async () => {
@@ -177,6 +193,68 @@ describe("session navigation", () => {
     const failingGit: GitRunner = async () => ({ stdout: "", stderr: "fatal", code: 128 });
     const navigation = new SessionNavigation(session, failingGit);
     navigation.recordTurnEnd(checkpoint("u1", "a1"));
-    expect(await navigation.undo()).toBe("git_failed");
+    expect((await navigation.undo()).status).toBe("git_failed");
+  });
+  it("supports repeated session-only undo and redo", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(sessionCheckpoint("u1", "a1"));
+    await navigation.recordTurnEnd(sessionCheckpoint("u2", "a2"));
+
+    expect(await navigation.undo()).toEqual({
+      status: "moved",
+      files: "unavailable",
+      reason: "not_repository",
+    });
+    expect(await navigation.undo()).toEqual({
+      status: "moved",
+      files: "unavailable",
+      reason: "not_repository",
+    });
+    expect(await navigation.redo()).toEqual({
+      status: "moved",
+      files: "unavailable",
+      reason: "not_repository",
+    });
+    expect(await navigation.redo()).toEqual({
+      status: "moved",
+      files: "unavailable",
+      reason: "not_repository",
+    });
+  });
+
+  it("processes mixed Git and session-only history in order", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(checkpoint("u1", "a1"));
+    await navigation.recordTurnEnd(sessionCheckpoint("a1", "a2"));
+
+    expect((await navigation.undo()).files).toBe("unavailable");
+    expect((await navigation.undo()).files).toBe("restored");
+    expect((await navigation.redo()).files).toBe("restored");
+    expect((await navigation.redo()).files).toBe("unavailable");
+  });
+
+  it("does not move the history index when session navigation is cancelled", async () => {
+    const session = port();
+    session.navigateTree = async () => ({ cancelled: true });
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(sessionCheckpoint("u1", "a1"));
+
+    expect((await navigation.undo()).status).toBe("cancelled");
+    navigation.setNavigateTree(async () => ({ cancelled: false }));
+    expect((await navigation.undo()).status).toBe("moved");
+  });
+
+  it("does not call Git while disposing session-only entries", async () => {
+    let calls = 0;
+    const git: GitRunner = async () => {
+      calls++;
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const navigation = new SessionNavigation(port(), git);
+    await navigation.recordTurnEnd(sessionCheckpoint("u1", "a1"));
+    await navigation.dispose();
+    expect(calls).toBe(0);
   });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -96,6 +96,15 @@ async function makeRepository(): Promise<string> {
   return cwd;
 }
 
+async function makeUnbornRepository(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-unborn-"));
+  await git(cwd, ["init", "-q"]);
+  await git(cwd, ["config", "user.name", "test"]);
+  await git(cwd, ["config", "user.email", "test@example.com"]);
+  await git(cwd, ["config", "core.autocrlf", "false"]);
+  return cwd;
+}
+
 async function privateRefs(cwd: string): Promise<string[]> {
   const output = await git(cwd, ["for-each-ref", "--format=%(refname)", "refs/omp-undo-redo/"]);
   return output ? output.split("\n") : [];
@@ -125,6 +134,81 @@ async function prepareUndoneSession(
   await pi.runCommand("undo", ctx);
   return ctx;
 }
+
+describe("session-only lifecycle fallback", () => {
+  it("keeps non-Git turns undoable without changing files", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-non-git-lifecycle-"));
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = await prepareUndoneSession(pi, cwd, "non-git-session");
+
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("changed\n");
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Undid the session turn, but files were not restored because the working directory is not a Git repository.",
+      );
+      await pi.runCommand("redo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("changed\n");
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Redid the session turn, but files were not restored because the working directory is not a Git repository.",
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("restores files for turns in an unborn repository", async () => {
+    const cwd = await makeUnbornRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = await prepareUndoneSession(pi, cwd, "unborn-session");
+
+      await expect(readFile(join(cwd, "tracked.txt"))).rejects.toThrow();
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Undid last turn: session moved back and file snapshot restored.",
+      );
+      expect(await privateRefs(cwd)).toHaveLength(2);
+      await pi.runCommand("redo", ctx);
+      await expect(readFile(join(cwd, "tracked.txt"), "utf8")).resolves.toBe("changed\n");
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Redid last turn: session moved forward and file snapshot restored.",
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("retains a session boundary when after-snapshot creation fails", async () => {
+    const cwd = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = context(cwd, "after-failure-session");
+      await pi.emit("session_start", ctx);
+      await pi.emit("before_agent_start", ctx);
+      expect(await privateRefs(cwd)).toHaveLength(1);
+      await writeFile(join(cwd, "tracked.txt"), "changed\n");
+      await writeFile(join(cwd, ".git", "HEAD"), "not-a-head\n");
+      ctx.leaf = "turn";
+      await pi.emit("agent_end", ctx);
+      await writeFile(join(cwd, ".git", "HEAD"), "ref: refs/heads/master\n");
+      expect(await privateRefs(cwd)).toEqual([]);
+
+      ctx.navigateTree = async (targetId) => {
+        ctx.leaf = targetId;
+        return { cancelled: false };
+      };
+      await pi.runCommand("undo", ctx);
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Undid the session turn, but files were not restored because the Git repository has an invalid HEAD.",
+      );
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("changed\n");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("navigation invalidation lifecycle", () => {
   it("clears redo after unrelated session tree navigation", async () => {


### PR DESCRIPTION
## Summary\n- support full checkpoints in unborn repositories\n- retain session-only undo/redo when Git snapshots are unavailable\n- report stable checkpoint failure reasons\n- update documentation and release metadata for v1.0.23\n\n## Verification\n- npm run format:check\n- npm run lint\n- npm run typecheck\n- npm run build\n- npm run pack:check\n- npx vitest run --pool=forks --maxWorkers=1 --minWorkers=1