### PR TITLE
Fix navigation across file-history gaps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm-version.outputs.exists != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.24] - 2026-07-30
+
+### Fixed
+
+- Treat session-only checkpoints as file-history continuity barriers so older Git patches are never applied across unknown file changes.
+- Release invalidated private refs while allowing later Git checkpoints to start a new restorable file-history segment.
+
 ## [1.0.23] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The extension exposes exactly these commands:
 Commands take no arguments. They navigate OMP's session tree through the official extension API and do not create a new model turn.
 Both commands wait for the current agent turn to become idle; if OMP remains busy, the command leaves the session unchanged and shows a warning.
 
-Every completed turn remains undoable, including conversation-only turns and turns that change only ignored files. When a Git file checkpoint is available, `/undo` and `/redo` restore the corresponding worktree delta as part of the same operation. If Git checkpoint creation is unavailable, the commands navigate session context only, leave files unchanged, and explicitly report that limitation.
+Every completed turn remains navigable, including conversation-only turns and turns that change only ignored files. When a Git file checkpoint is available, `/undo` and `/redo` restore the corresponding worktree delta as part of the same operation. If Git checkpoint creation is unavailable, the commands navigate session context only, leave files unchanged, and explicitly report that limitation. Such a session-only checkpoint is a file-history continuity barrier: older file checkpoints are discarded because applying them across an unknown file delta would be unsafe. Later successful Git checkpoints start a new restorable file-history segment.
 
 ## Limitations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/commands/redo.ts
+++ b/src/commands/redo.ts
@@ -12,6 +12,8 @@ function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
       return "the Git repository could not be resolved.";
     case "invalid_head":
       return "the Git repository has an invalid HEAD.";
+    case "file_history_gap":
+      return "a later turn had no file checkpoint, so this older file checkpoint was discarded.";
     default:
       return "the file checkpoint could not be created.";
   }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -12,6 +12,8 @@ function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
       return "the Git repository could not be resolved.";
     case "invalid_head":
       return "the Git repository has an invalid HEAD.";
+    case "file_history_gap":
+      return "a later turn had no file checkpoint, so this older file checkpoint was discarded.";
     default:
       return "the file checkpoint could not be created.";
   }

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -75,17 +75,34 @@ export class SessionNavigation {
     );
   }
 
+  private convertEarlierGitCheckpoints(): GitCheckpoint[] {
+    const converted: GitCheckpoint[] = [];
+    for (let index = 0; index < this.checkpoints.length; index++) {
+      const entry = this.checkpoints[index];
+      if (entry.kind !== "git") continue;
+      converted.push(entry);
+      this.checkpoints[index] = {
+        kind: "session",
+        reason: "file_history_gap",
+        parentLeafId: entry.parentLeafId,
+        leafId: entry.leafId,
+      };
+    }
+    return converted;
+  }
+
   async recordTurnEnd(checkpoint: TurnCheckpoint): Promise<void> {
     const discarded = this.checkpoints.splice(
       this.currentIndex + 1,
       this.checkpoints.length - this.currentIndex - 1,
     );
+    const converted = checkpoint.kind === "session" ? this.convertEarlierGitCheckpoints() : [];
     this.checkpoints.push(checkpoint);
     this.currentIndex = this.checkpoints.length - 1;
-    await releaseCheckpoints(
-      this.gitForRepository,
-      discarded.filter((entry): entry is GitCheckpoint => entry.kind === "git"),
-    );
+    await releaseCheckpoints(this.gitForRepository, [
+      ...discarded.filter((entry): entry is GitCheckpoint => entry.kind === "git"),
+      ...converted,
+    ]);
   }
 
   async dispose(): Promise<void> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,7 +19,8 @@ export type FileCheckpointUnavailableReason =
   | "before_snapshot_failed"
   | "before_ref_failed"
   | "after_snapshot_failed"
-  | "after_ref_failed";
+  | "after_ref_failed"
+  | "file_history_gap";
 
 export type TreeNavigationResult = {
   cancelled: boolean;

--- a/test/command-behavior.test.ts
+++ b/test/command-behavior.test.ts
@@ -223,16 +223,28 @@ describe("session navigation", () => {
     });
   });
 
-  it("processes mixed Git and session-only history in order", async () => {
+  it("treats a session-only checkpoint as a file-history continuity barrier", async () => {
     const session = port();
     const navigation = makeNavigation(session);
     await navigation.recordTurnEnd(checkpoint("u1", "a1"));
     await navigation.recordTurnEnd(sessionCheckpoint("a1", "a2"));
 
-    expect((await navigation.undo()).files).toBe("unavailable");
-    expect((await navigation.undo()).files).toBe("restored");
-    expect((await navigation.redo()).files).toBe("restored");
-    expect((await navigation.redo()).files).toBe("unavailable");
+    expect(await navigation.undo()).toMatchObject({
+      files: "unavailable",
+      reason: "not_repository",
+    });
+    expect(await navigation.undo()).toMatchObject({
+      files: "unavailable",
+      reason: "file_history_gap",
+    });
+    expect(await navigation.redo()).toMatchObject({
+      files: "unavailable",
+      reason: "file_history_gap",
+    });
+    expect(await navigation.redo()).toMatchObject({
+      files: "unavailable",
+      reason: "not_repository",
+    });
   });
 
   it("does not move the history index when session navigation is cancelled", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -208,6 +208,60 @@ describe("session-only lifecycle fallback", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("keeps undo and redo traversable across a file-history gap", async () => {
+    const cwd = await makeRepository();
+    try {
+      const pi = new FakeExtensionApi();
+      ompUndoRedo(pi as never);
+      const ctx = context(cwd, "file-history-gap-session");
+      await pi.emit("session_start", ctx);
+      ctx.navigateTree = async (targetId) => {
+        ctx.leaf = targetId;
+        return { cancelled: false };
+      };
+
+      await pi.emit("before_agent_start", ctx);
+      await writeFile(join(cwd, "tracked.txt"), "B\n");
+      ctx.leaf = "turn-1";
+      await pi.emit("agent_end", ctx);
+      expect(await privateRefs(cwd)).toHaveLength(2);
+
+      await pi.emit("before_agent_start", ctx);
+      await writeFile(join(cwd, "tracked.txt"), "C\n");
+      const head = await readFile(join(cwd, ".git", "HEAD"), "utf8");
+      await writeFile(join(cwd, ".git", "HEAD"), "not-a-head\n");
+      ctx.leaf = "turn-2";
+      await pi.emit("agent_end", ctx);
+      await writeFile(join(cwd, ".git", "HEAD"), head);
+      expect(await privateRefs(cwd)).toEqual([]);
+
+      await pi.emit("before_agent_start", ctx);
+      await writeFile(join(cwd, "tracked.txt"), "D\n");
+      ctx.leaf = "turn-3";
+      await pi.emit("agent_end", ctx);
+      expect(await privateRefs(cwd)).toHaveLength(2);
+
+      await pi.runCommand("undo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("C\n");
+      await pi.runCommand("undo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("C\n");
+      await pi.runCommand("undo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("C\n");
+      expect(ctx.ui.notifications.at(-1)?.message).toBe(
+        "Undid the session turn, but files were not restored because a later turn had no file checkpoint, so this older file checkpoint was discarded.",
+      );
+
+      await pi.runCommand("redo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("C\n");
+      await pi.runCommand("redo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("C\n");
+      await pi.runCommand("redo", ctx);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("D\n");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("navigation invalidation lifecycle", () => {


### PR DESCRIPTION
## Summary
- treat session-only checkpoints as file-history continuity barriers
- release unsafe older Git checkpoint refs while preserving session undo and redo
- add real-Git overlapping lifecycle coverage
- release v1.0.24

## Verification
- npm run verify