### PR TITLE
fix: clean dist build and package parity check v1.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.26] - 2026-07-31
+
+### Fixed
+
+- Ensure clean `dist/` build by removing output directory before emitting compiled files and enforcing exact output path parity with `src/**/*.ts`.
+- Automatically trigger clean build before `npm pack` and `npm publish` via `prepack` hook to prevent stale or orphaned generated artifacts from being packaged.
+- Add package entry smoke check (`npm run smoke:package`) to verify the compiled extension loads and registers commands correctly without behavior changes to `/undo` or `/redo`.
+
 ## [1.0.25] - 2026-07-30
 
 ### Fixed
@@ -168,6 +176,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
+[1.0.26]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.26
 [1.0.25]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.25
 [1.0.24]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.24
 [1.0.23]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.23

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Undo/redo has two modes. **Full mode** creates private Git snapshot objects thro
 
 Install dependencies with npm, then use the scripts in `package.json`:
 
-- `npm run build` compiles `src/` to `dist/`.
+- `npm run build` replaces `dist/` rather than incrementally accumulating files, compiling `src/` to `dist/` and enforcing output parity.
 - `npm run typecheck` checks TypeScript without emitting files.
 - `npm test` runs the deterministic test suite.
 - `npm run lint` and `npm run format:check` check style.
@@ -102,7 +102,7 @@ The implementation uses only public OMP extension APIs. Keep changes focused, pr
 
 ## Release
 
-A release consists of a reviewed change, a clean verification run, an updated `CHANGELOG.md` entry, and a published npm package containing `index.js`, `dist/`, `README.md`, `LICENSE`, and `CHANGELOG.md`. The package manifest is the source of truth for the extension entry point and peer compatibility. Never place npm tokens, registry credentials, or other secrets in the repository or release logs.
+A release consists of a reviewed change, a clean verification run (enforcing exact generated-output parity and running the compiled package-entry smoke check), an updated `CHANGELOG.md` entry, and a published npm package containing `index.js`, `dist/`, `README.md`, `LICENSE`, and `CHANGELOG.md`. The package manifest is the source of truth for the extension entry point and peer compatibility. Never place npm tokens, registry credentials, or other secrets in the repository or release logs.
 
 ## Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",
@@ -34,15 +34,20 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "clean": "node scripts/clean-dist.mjs",
+    "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.json",
+    "postbuild": "node scripts/check-dist.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepack": "npm run build",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "smoke:package": "node scripts/smoke-package.mjs",
     "pack:check": "npm pack --dry-run",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build && npm run pack:check"
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build && npm run smoke:package && npm run pack:check"
   },
   "peerDependencies": {
     "@oh-my-pi/pi-coding-agent": ">=16.5.2"

--- a/scripts/check-dist.mjs
+++ b/scripts/check-dist.mjs
@@ -1,0 +1,65 @@
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const srcDir = join(rootDir, "src");
+const distDir = join(rootDir, "dist");
+
+async function getFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true }).catch((err) => {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await getFiles(fullPath)));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function normalizePath(p) {
+  return p.replace(/\\/g, "/");
+}
+
+const srcFiles = await getFiles(srcDir);
+const expectedDistFiles = new Set();
+
+for (const srcFile of srcFiles) {
+  const rel = normalizePath(relative(srcDir, srcFile));
+  if (rel.endsWith(".ts")) {
+    const base = rel.slice(0, -3);
+    expectedDistFiles.add(`dist/${base}.js`);
+    expectedDistFiles.add(`dist/${base}.d.ts`);
+  }
+}
+
+const actualDistFilesRaw = await getFiles(distDir);
+const actualDistFiles = new Set(actualDistFilesRaw.map((f) => normalizePath(relative(rootDir, f))));
+
+const missing = [...expectedDistFiles].filter((f) => !actualDistFiles.has(f)).sort();
+const unexpected = [...actualDistFiles].filter((f) => !expectedDistFiles.has(f)).sort();
+
+if (missing.length > 0 || unexpected.length > 0) {
+  console.error("Build output parity check failed:");
+  if (missing.length > 0) {
+    console.error("Missing expected dist files:");
+    for (const f of missing) {
+      console.error(`  - ${f}`);
+    }
+  }
+  if (unexpected.length > 0) {
+    console.error("Unexpected dist files:");
+    for (const f of unexpected) {
+      console.error(`  - ${f}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("Build output parity check passed.");

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,5 @@
+import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const distPath = fileURLToPath(new URL("../dist", import.meta.url));
+await rm(distPath, { recursive: true, force: true });

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -1,0 +1,56 @@
+import ompUndoRedo from "../index.js";
+
+if (typeof ompUndoRedo !== "function") {
+  console.error("Package default export is not a function.");
+  process.exit(1);
+}
+
+const registeredCommands = new Map();
+const registeredEvents = new Map();
+
+const fakeApi = {
+  on(event, handler) {
+    if (typeof handler !== "function") {
+      throw new Error(`Event handler for '${event}' is not a function.`);
+    }
+    registeredEvents.set(event, (registeredEvents.get(event) || 0) + 1);
+  },
+  registerCommand(name, config) {
+    if (registeredCommands.has(name)) {
+      throw new Error(`Duplicate command registration for '${name}'.`);
+    }
+    if (!config || typeof config.handler !== "function") {
+      throw new Error(`Command '${name}' missing callable handler.`);
+    }
+    registeredCommands.set(name, config);
+  },
+};
+
+try {
+  ompUndoRedo(fakeApi);
+} catch (error) {
+  console.error("Failed to invoke default extension export:", error);
+  process.exit(1);
+}
+
+const requiredCommands = ["undo", "redo"];
+for (const cmd of requiredCommands) {
+  const config = registeredCommands.get(cmd);
+  if (!config) {
+    console.error(`Required command '${cmd}' was not registered.`);
+    process.exit(1);
+  }
+  if (typeof config.handler !== "function") {
+    console.error(`Registered command '${cmd}' handler is not a function.`);
+    process.exit(1);
+  }
+}
+
+if (registeredCommands.size !== requiredCommands.length) {
+  console.error(
+    `Unexpected commands registered: expected ${requiredCommands.length}, got ${registeredCommands.size}.`,
+  );
+  process.exit(1);
+}
+
+console.log("Package entry smoke test passed successfully.");


### PR DESCRIPTION
## Description
Enforces clean `dist/` build by removing `dist/` in `prebuild` (`scripts/clean-dist.mjs`), checks exact output parity in `postbuild` (`scripts/check-dist.mjs`), triggers clean builds before `npm pack` and `npm publish` via `prepack`, and verifies compiled package loading with `npm run smoke:package`.

## Verification
- Local `npm run verify` passed cleanly (formatting, linting, typechecking, 47 unit/integration tests, clean build, smoke test, pack check).
- Stale sentinels and missing output paths cause `check-dist` failures as intended.
- `npm pack --dry-run` produces exactly 17 expected package files with no orphan artifacts.