### PR TITLE
fix: stabilize staged index regression across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.28] - 2026-07-31
+
+### Fixed
+
+- Make staged-state regression assertions stable across Git platforms by separating extension apply checks from Git index stat refreshes.
+
 ## [1.0.27] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -282,10 +282,11 @@ describe("history-safe Git checkpoints", () => {
       expect(
         await text(git, ["diff", "--", "tracked.txt"], { env: { GIT_OPTIONAL_LOCKS: "0" } }),
       ).toContain("-turn\n+base");
+      const indexBeforeRedo = await readFile(savedIndexPath);
 
       expect(await applyCheckpoint(git, after.beforeHash, after.afterHash)).toBe("applied");
       expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("turn\n");
-      expect(await readFile(savedIndexPath)).toEqual(savedIndex.raw);
+      expect(await readFile(savedIndexPath)).toEqual(indexBeforeRedo);
       expect(await text(git, ["write-tree"])).toBe(savedIndex.tree);
       expect(await text(git, ["status", "--short"], { env: { GIT_OPTIONAL_LOCKS: "0" } })).toBe(
         "M  tracked.txt",


### PR DESCRIPTION
## Summary
- stabilize staged-index byte assertions when Git refreshes index stat metadata after inspection
- release corrective version 1.0.28 after v1.0.27 CI verification exposed the Linux-specific test failure

## Verification
- npx vitest run test/checkpoints.test.ts -t "preserves staged turn state"
- npm test (48 passed)
- npm run lint
- npm run typecheck
- npm run build
- npm run smoke:package
- npm run pack:check

The v1.0.27 tag remains immutable and was not reused.