### PR TITLE
feat: automate stale checkpoint cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.29] - 2026-07-31
+
+### Added
+
+- Add conservative owner-scoped checkpoint leases and automatic cleanup for provably stale same-host runtimes, with runtime-scope protection for Linux PID namespaces.
+
+### Fixed
+
+- Preserve full undo/redo through legacy ownerless fallback when lease publication is unavailable.
+- Bound maintenance Git operations and keep stale cleanup asynchronous, compare-and-delete based, and safe under concurrent runtimes.
+
 ## [1.0.28] - 2026-07-31
 
 ### Fixed
 
 - Make staged-state regression assertions stable across Git platforms by separating extension apply checks from Git index stat refreshes.
+- Add conservative owner-scoped v2 checkpoint refs with repository-local leases and asynchronous cleanup for only provably stale same-host owners. Linux cleanup is additionally bound to kernel boot and PID namespace identity; unresolved runtime scope, existing ownerless refs, and uncertain ownership cases remain manual-cleanup paths.
+- Make the Prettier verification gate honor the checked-out platform line endings so Windows CRLF worktrees do not fail on otherwise formatted files.
 
 ## [1.0.27] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ Every completed turn remains navigable, including conversation-only turns and tu
 
 Undo/redo has two modes. **Full mode** creates private Git snapshot objects through an alternate index and `git commit-tree`, then retains them with refs under `refs/omp-undo-redo/`; `/undo` and `/redo` restore only the worktree snapshot and navigate session context. **Session-only mode** navigates session context without changing files when Git is unavailable, the cwd is outside a repository, the repository cannot be resolved, `HEAD` is invalid, or snapshot creation fails. Checkpoint creation never moves `HEAD` or any branch ref. The real Git index is preserved, and releasing a checkpoint removes its private refs. A checkpoint covers the complete Git worktree that contains the session cwd; starting OMP from a repository subdirectory does not limit undo/redo to that subtree. Dirty files that existed before the turn are included in both snapshots and remain unchanged by undo/redo. Changes made anywhere in the repository during the turn can be part of the checkpoint because Git snapshots cannot determine authorship; this is an architectural limitation. Ignored files, empty directories, dirty submodule contents, shell effects, network effects, and editor state are outside the checkpoint. Clean/smudge filters, `core.autocrlf`, submodules, and ignored files prevent a universal byte-for-byte guarantee. If overlapping worktree changes prevent safe application, undo/redo fails instead of overwriting them. Graceful session shutdown releases active and pending private refs. Forced termination, process kill, shutdown-handler timeout, or Git cleanup failure can still leave stale private refs; inspect them with `git for-each-ref refs/omp-undo-redo/` and remove only confirmed stale refs. Do not delete refs from a repository while another OMP process may still be using them.
 
+### Checkpoint ownership and stale cleanup
+
+New full-mode checkpoints use owner-scoped v2 refs:
+
+```text
+refs/omp-undo-redo/v2/<ownerId>/<sessionHash>/<checkpointId>/before
+refs/omp-undo-redo/v2/<ownerId>/<sessionHash>/<checkpointId>/after
+```
+
+The extension publishes a repository-local lease before it creates a v2 ref. A later runtime automatically removes refs only when the lease is valid, has the same persistent host ID, hostname, and runtime scope, and its PID probe returns `ESRCH`. On Linux, the runtime scope binds cleanup to both the current kernel boot ID and PID namespace, preventing a container or WSL process outside that namespace from being mistaken for a dead local process. If that scope cannot be resolved, automatic cleanup is disabled while v2 checkpointing and graceful cleanup continue. Current, live, remote, malformed, future-version, unreadable, and otherwise uncertain owners are preserved. Existing ownerless refs are always manual-cleanup refs. Automatic maintenance runs once per runtime and repository, in the background, with bounded Git operations; maintenance failure does not block checkpoint creation or commands.
+
+For manual inspection, stop all OMP/Pi processes that use the repository, then use Git commands only:
+
+```sh
+git for-each-ref --format="%(refname) %(objectname)" refs/omp-undo-redo/
+git update-ref -d <exact-ref> <expected-object-id>
+```
+
+Replace the placeholders with the exact ref and object ID printed by the first command. Do not delete a ref by name alone. Removing a ref makes its objects eligible for later Git reclamation; it does not immediately or securely erase the object data. Unreadable host identity or Linux runtime-scope state, malformed leases, and future ref versions remain manual-cleanup cases. The persistent host-ID directory must not be copied or shared between independent native machines that use the same repository and hostname; native Windows and macOS cleanup assumes that identity is machine-local.
+
 ### Git index and staged changes
 
 `/undo` and `/redo` are worktree operations, not staging operations. Staged changes that existed before or were created during a turn remain staged, even when navigation restores an earlier worktree snapshot. A touched path can therefore show `MM`, `AM`, `MD`, or another two-column porcelain state after navigation. `git diff --cached` shows what a commit would take from the preserved index. `git diff` shows unstaged differences between that index and the restored worktree. Inspect both views and deliberately stage the desired files before committing. The extension does not recommend an automatic `git add -A`, `git reset`, or `git restore --staged` command because each can alter unrelated staging intent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -6,5 +6,5 @@ export default {
   semi: true,
   singleQuote: false,
   trailingComma: "all",
-  endOfLine: "lf",
+  endOfLine: "auto",
 };

--- a/src/core/checkpoint-owners.ts
+++ b/src/core/checkpoint-owners.ts
@@ -1,0 +1,555 @@
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, open, readFile, readdir, readlink, rename, rm, stat } from "node:fs/promises";
+import { hostname as systemHostname, homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import type { GitRepository, GitRunner, GitCommandResult, OwnershipMode } from "./types.js";
+
+export const CHECKPOINT_OWNER_REF_ROOT = "refs/omp-undo-redo/v2";
+export const CHECKPOINT_OWNER_LEASE_SCHEMA = 1;
+const MAX_LEASE_BYTES = 64 * 1024;
+const DEFAULT_CLEANUP_TIMEOUT_MS = 1_000;
+const DEFAULT_SHUTDOWN_WAIT_MS = 1_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const RUNTIME_SCOPE_PATTERN = /^[0-9a-f]{64}$/;
+
+export interface ParsedCheckpointRef {
+  ownerId: string;
+  sessionHash: string;
+  checkpointId: string;
+  phase: "before" | "after";
+}
+
+export interface CheckpointOwnerLease {
+  schemaVersion: 1;
+  ownerId: string;
+  hostId: string;
+  hostname: string;
+  runtimeScope: string;
+  pid: number;
+  startedAt: string;
+}
+
+export type LeaseClassification = "alive" | "remote" | "stale" | "unknown";
+
+export interface HostIdentity {
+  id: string | null;
+  persistent: boolean;
+}
+
+export interface HostIdentityOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homeDirectory?: string;
+  randomId?: () => string;
+  readFile?: typeof readFile;
+  readlink?: typeof readlink;
+}
+
+export interface LivenessOptions {
+  currentOwnerId: string;
+  currentHostId: string | null;
+  currentHostname: string;
+  currentRuntimeScope: string | null;
+  probePid?: (pid: number) => void;
+}
+
+export interface OwnerRegistryOptions {
+  ownerId?: string;
+  hostIdentity?: HostIdentity;
+  hostname?: string;
+  runtimeScope?: string | null;
+  maxConcurrentOwners?: number;
+  cleanupTimeoutMs?: number;
+  shutdownWaitMs?: number;
+  now?: () => Date;
+  resolveHostIdentity?: () => Promise<HostIdentity>;
+  resolveRuntimeScope?: () => Promise<string | null>;
+  probePid?: (pid: number) => void;
+}
+
+export function isCanonicalUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+export function isSha256Hash(value: string): boolean {
+  return SHA256_PATTERN.test(value);
+}
+
+export function isGitObjectId(value: string): boolean {
+  return OBJECT_ID_PATTERN.test(value);
+}
+
+export function parseCheckpointOwnerRef(ref: string): ParsedCheckpointRef | null {
+  const parts = ref.split("/");
+  if (parts.length !== 7) return null;
+  if (parts.slice(0, 3).join("/") !== CHECKPOINT_OWNER_REF_ROOT) return null;
+  const [, , , ownerId, sessionHash, checkpointId, phase] = parts;
+  if (!isCanonicalUuid(ownerId) || !isSha256Hash(sessionHash) || !isCanonicalUuid(checkpointId)) {
+    return null;
+  }
+  if (phase !== "before" && phase !== "after") return null;
+  return { ownerId, sessionHash, checkpointId, phase };
+}
+
+export function ownerCheckpointPrefix(ownerId: string): string | null {
+  return isCanonicalUuid(ownerId) ? `${CHECKPOINT_OWNER_REF_ROOT}/${ownerId}/` : null;
+}
+
+export function parseCheckpointOwnerLease(
+  filename: string,
+  contents: string,
+): CheckpointOwnerLease | null {
+  if (!filename.endsWith(".json")) return null;
+  const filenameOwner = filename.slice(0, -5);
+  if (!isCanonicalUuid(filenameOwner) || Buffer.byteLength(contents, "utf8") > MAX_LEASE_BYTES)
+    return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(contents);
+  } catch {
+    return null;
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort().join(",");
+  if (keys !== "hostId,hostname,ownerId,pid,runtimeScope,schemaVersion,startedAt") return null;
+  if (
+    record.schemaVersion !== CHECKPOINT_OWNER_LEASE_SCHEMA ||
+    record.ownerId !== filenameOwner ||
+    typeof record.ownerId !== "string" ||
+    !isCanonicalUuid(record.ownerId) ||
+    typeof record.hostId !== "string" ||
+    !isCanonicalUuid(record.hostId) ||
+    typeof record.hostname !== "string" ||
+    record.hostname.length === 0 ||
+    record.hostname.length > 255 ||
+    typeof record.pid !== "number" ||
+    !Number.isSafeInteger(record.pid) ||
+    record.pid <= 0 ||
+    typeof record.runtimeScope !== "string" ||
+    !RUNTIME_SCOPE_PATTERN.test(record.runtimeScope) ||
+    typeof record.startedAt !== "string" ||
+    !Number.isFinite(Date.parse(record.startedAt))
+  ) {
+    return null;
+  }
+  return record as unknown as CheckpointOwnerLease;
+}
+
+function hostIdentityPath(options: HostIdentityOptions): string {
+  const selectedPlatform = options.platform ?? platform();
+  const env = options.env ?? process.env;
+  const home = options.homeDirectory ?? homedir();
+  if (selectedPlatform === "win32") {
+    return join(env.LOCALAPPDATA ?? join(home, "AppData", "Local"), "omp-undo-redo", "host-id");
+  }
+  if (selectedPlatform === "darwin") {
+    return join(home, "Library", "Application Support", "omp-undo-redo", "host-id");
+  }
+  return join(env.XDG_STATE_HOME ?? join(home, ".local", "state"), "omp-undo-redo", "host-id");
+}
+
+async function readValidUuid(path: string): Promise<string | null | "unreadable"> {
+  try {
+    const value = (await readFile(path, "utf8")).trim();
+    return isCanonicalUuid(value) ? value : "unreadable";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT" ? null : "unreadable";
+  }
+}
+
+async function writeExclusive(path: string, contents: string): Promise<boolean> {
+  let handle;
+  try {
+    handle = await open(path, "wx", 0o600);
+    await handle.writeFile(contents, "utf8");
+    await handle.close();
+    return true;
+  } catch {
+    await handle?.close().catch(() => undefined);
+    return false;
+  }
+}
+
+export async function resolvePersistentHostId(
+  options: HostIdentityOptions = {},
+): Promise<HostIdentity> {
+  const path = hostIdentityPath(options);
+  const existing = await readValidUuid(path);
+  if (existing === "unreadable") return { id: null, persistent: false };
+  if (existing) return { id: existing, persistent: true };
+  const id = (options.randomId ?? randomUUID)();
+  if (!isCanonicalUuid(id)) return { id: null, persistent: false };
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    if (!(await writeExclusive(temporary, `${id}\n`))) {
+      const winner = await readValidUuid(path);
+      return winner && winner !== "unreadable"
+        ? { id: winner, persistent: true }
+        : { id: null, persistent: false };
+    }
+    try {
+      await link(temporary, path);
+      await rm(temporary, { force: true });
+      return { id, persistent: true };
+    } catch {
+      const winner = await readValidUuid(path);
+      return winner && winner !== "unreadable"
+        ? { id: winner, persistent: true }
+        : { id: null, persistent: false };
+    }
+  } catch {
+    return { id: null, persistent: false };
+  } finally {
+    await rm(temporary, { force: true }).catch(() => undefined);
+  }
+}
+
+export async function resolveRuntimeScope(
+  options: HostIdentityOptions = {},
+): Promise<string | null> {
+  const selectedPlatform = options.platform ?? platform();
+  if (selectedPlatform !== "linux") {
+    return createHash("sha256").update(`native-process-table:${selectedPlatform}`).digest("hex");
+  }
+  const readText = options.readFile ?? readFile;
+  const readLink = options.readlink ?? readlink;
+  try {
+    const [bootId, pidNamespace] = await Promise.all([
+      readText("/proc/sys/kernel/random/boot_id", "utf8"),
+      readLink("/proc/self/ns/pid"),
+    ]);
+    const boot = bootId.trim();
+    if (!isCanonicalUuid(boot) || !/^pid:\[\d+\]$/.test(pidNamespace)) return null;
+    return createHash("sha256").update(`linux:${boot}:${pidNamespace}`).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+export function classifyCheckpointOwner(
+  lease: CheckpointOwnerLease,
+  options: LivenessOptions,
+): LeaseClassification {
+  if (lease.ownerId === options.currentOwnerId) return "alive";
+  if (!options.currentHostId || !options.currentRuntimeScope) return "unknown";
+  if (
+    lease.hostId !== options.currentHostId ||
+    lease.hostname !== options.currentHostname ||
+    lease.runtimeScope !== options.currentRuntimeScope
+  )
+    return "remote";
+  try {
+    (options.probePid ?? ((pid) => process.kill(pid, 0)))(lease.pid);
+    return "alive";
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return "stale";
+    return "unknown";
+  }
+}
+
+function leaseDirectory(repository: GitRepository): string {
+  return join(repository.commonDir, "omp-undo-redo", "owners");
+}
+
+function leasePath(repository: GitRepository, ownerId: string): string {
+  return join(leaseDirectory(repository), `${ownerId}.json`);
+}
+
+function leaseContents(
+  ownerId: string,
+  hostId: string,
+  hostname: string,
+  runtimeScope: string,
+  now: () => Date,
+): string {
+  return JSON.stringify({
+    schemaVersion: CHECKPOINT_OWNER_LEASE_SCHEMA,
+    ownerId,
+    hostId,
+    hostname,
+    pid: process.pid,
+    runtimeScope,
+    startedAt: now().toISOString(),
+  });
+}
+async function removeCurrentOwnerTemporaryFiles(directory: string, ownerId: string): Promise<void> {
+  const pattern = new RegExp(`^\\.${ownerId}\\.[0-9a-f-]{36}\\.tmp$`);
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && pattern.test(entry.name))
+      .map((entry) => rm(join(directory, entry.name), { force: true }).catch(() => undefined)),
+  );
+}
+
+async function publishLease(
+  repository: GitRepository,
+  ownerId: string,
+  hostId: string,
+  hostname: string,
+  runtimeScope: string,
+  now: () => Date,
+): Promise<boolean> {
+  const directory = leaseDirectory(repository);
+  const finalPath = leasePath(repository, ownerId);
+  const temporary = join(directory, `.${ownerId}.${randomUUID()}.tmp`);
+  try {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await removeCurrentOwnerTemporaryFiles(directory, ownerId);
+    if (
+      !(await writeExclusive(
+        temporary,
+        leaseContents(ownerId, hostId, hostname, runtimeScope, now),
+      ))
+    )
+      return false;
+    await rename(temporary, finalPath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await rm(temporary, { force: true }).catch(() => undefined);
+  }
+}
+
+async function enumerateOwnerRefs(
+  git: GitRunner,
+  repository: GitRepository,
+  ownerId: string,
+  timeoutMs: number,
+): Promise<{ ok: true; refs: Array<{ ref: string; expectedHash: string }> } | { ok: false }> {
+  const prefix = ownerCheckpointPrefix(ownerId);
+  if (!prefix) return { ok: false };
+  let result: GitCommandResult;
+  try {
+    result = await git(["for-each-ref", "--format=%(refname)%00%(objectname)", prefix], {
+      env: { GIT_DIR: repository.commonDir },
+      timeoutMs,
+    });
+  } catch {
+    return { ok: false };
+  }
+  if (result.error || result.code !== 0) return { ok: false };
+  const refs: Array<{ ref: string; expectedHash: string }> = [];
+  for (const line of result.stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    const separator = line.indexOf("\0");
+    if (separator < 0 || line.indexOf("\0", separator + 1) >= 0) return { ok: false };
+    const ref = line.slice(0, separator);
+    const expectedHash = line.slice(separator + 1);
+    const parsed = parseCheckpointOwnerRef(ref);
+    if (!parsed || parsed.ownerId !== ownerId || !isGitObjectId(expectedHash)) return { ok: false };
+    refs.push({ ref, expectedHash });
+  }
+  return { ok: true, refs };
+}
+
+async function deleteOwnerRefs(
+  git: GitRunner,
+  repository: GitRepository,
+  refs: readonly { ref: string; expectedHash: string }[],
+  timeoutMs: number,
+): Promise<"ok" | "failed" | "timeout"> {
+  if (refs.length === 0) return "ok";
+  const input = refs.map(({ ref, expectedHash }) => `delete ${ref} ${expectedHash}`).join("\n");
+  let result: GitCommandResult;
+  try {
+    result = await git(["update-ref", "--stdin"], {
+      env: { GIT_DIR: repository.commonDir },
+      stdin: `${input}\n`,
+      timeoutMs,
+    });
+  } catch {
+    return "failed";
+  }
+  if (result.error === "timeout") return "timeout";
+  if (result.code === 0) return "ok";
+  if (refs.length === 1) return "failed";
+  const midpoint = Math.ceil(refs.length / 2);
+  const left = await deleteOwnerRefs(git, repository, refs.slice(0, midpoint), timeoutMs);
+  if (left === "timeout") return "timeout";
+  const right = await deleteOwnerRefs(git, repository, refs.slice(midpoint), timeoutMs);
+  if (right === "timeout") return "timeout";
+  return left === "ok" && right === "ok" ? "ok" : "failed";
+}
+
+async function cleanupStaleOwner(
+  git: GitRunner,
+  repository: GitRepository,
+  ownerId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const first = await enumerateOwnerRefs(git, repository, ownerId, timeoutMs);
+  if (!first.ok) return;
+  const deletion = await deleteOwnerRefs(git, repository, first.refs, timeoutMs);
+  if (deletion === "timeout") return;
+  const second = await enumerateOwnerRefs(git, repository, ownerId, timeoutMs);
+  if (!second.ok || second.refs.length !== 0) return;
+  await rm(leasePath(repository, ownerId), { force: true }).catch(() => undefined);
+}
+
+export class CheckpointOwnerRegistry {
+  readonly ownerId: string;
+  private readonly hostname: string;
+  private readonly options: Required<
+    Pick<OwnerRegistryOptions, "maxConcurrentOwners" | "cleanupTimeoutMs" | "shutdownWaitMs">
+  >;
+  private readonly now: () => Date;
+  private readonly probePid: (pid: number) => void;
+  private readonly hostIdentityPromise: Promise<HostIdentity>;
+  private readonly runtimeScopePromise: Promise<string | null>;
+  private readonly initializations = new Map<string, Promise<OwnershipMode>>();
+  private readonly initialized = new Map<string, { repository: GitRepository; git: GitRunner }>();
+  private readonly scans = new Set<Promise<void>>();
+  constructor(options: OwnerRegistryOptions = {}) {
+    const configuredOwnerId = options.ownerId;
+    this.ownerId =
+      configuredOwnerId && isCanonicalUuid(configuredOwnerId) ? configuredOwnerId : randomUUID();
+    this.hostname = options.hostname ?? systemHostname();
+    this.options = {
+      maxConcurrentOwners: Math.max(1, options.maxConcurrentOwners ?? 4),
+      cleanupTimeoutMs: Math.max(1, options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS),
+      shutdownWaitMs: Math.max(1, options.shutdownWaitMs ?? DEFAULT_SHUTDOWN_WAIT_MS),
+    };
+    this.now = options.now ?? (() => new Date());
+    this.probePid = options.probePid ?? ((pid) => process.kill(pid, 0));
+    this.hostIdentityPromise = (
+      options.resolveHostIdentity
+        ? options.resolveHostIdentity()
+        : Promise.resolve(options.hostIdentity ?? { id: null, persistent: false })
+    ).catch(() => ({ id: null, persistent: false }));
+    this.runtimeScopePromise = (
+      options.resolveRuntimeScope
+        ? options.resolveRuntimeScope()
+        : Promise.resolve(options.runtimeScope ?? null)
+    ).catch(() => null);
+  }
+
+  async ensureInitialized(repository: GitRepository, git: GitRunner): Promise<OwnershipMode> {
+    const key = repository.commonDir;
+    if (this.initialized.has(key)) return "v2";
+    const existing = this.initializations.get(key);
+    if (existing) return existing;
+    const attempt = this.initialize(repository, git);
+    this.initializations.set(key, attempt);
+    try {
+      return await attempt;
+    } finally {
+      this.initializations.delete(key);
+    }
+  }
+
+  private async initialize(repository: GitRepository, git: GitRunner): Promise<OwnershipMode> {
+    const [host, resolvedRuntimeScope] = await Promise.all([
+      this.hostIdentityPromise,
+      this.runtimeScopePromise,
+    ]);
+    const hostId = host.id ?? randomUUID();
+    const leaseRuntimeScope =
+      resolvedRuntimeScope ?? createHash("sha256").update(randomUUID()).digest("hex");
+    if (
+      !(await publishLease(
+        repository,
+        this.ownerId,
+        hostId,
+        this.hostname,
+        leaseRuntimeScope,
+        this.now,
+      ))
+    )
+      return "legacy";
+    this.initialized.set(repository.commonDir, { repository, git });
+    if (host.persistent && resolvedRuntimeScope)
+      this.startScan(repository, git, hostId, resolvedRuntimeScope);
+    return "v2";
+  }
+
+  private startScan(
+    repository: GitRepository,
+    git: GitRunner,
+    hostId: string,
+    runtimeScope: string,
+  ): void {
+    const scan = this.scan(repository, git, hostId, runtimeScope).catch(() => undefined);
+    this.scans.add(scan);
+    void scan.finally(() => this.scans.delete(scan));
+  }
+
+  private async scan(
+    repository: GitRepository,
+    git: GitRunner,
+    hostId: string,
+    runtimeScope: string,
+  ): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(leaseDirectory(repository), { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return;
+      return;
+    }
+    const candidates: Array<{ ownerId: string }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const filePath = join(leaseDirectory(repository), entry.name);
+      const metadata = await stat(filePath).catch(() => null);
+      if (!metadata || metadata.size > MAX_LEASE_BYTES) continue;
+      const contents = await readFile(filePath, "utf8").catch(() => null);
+      if (contents === null) continue;
+      const lease = parseCheckpointOwnerLease(entry.name, contents);
+      if (!lease) continue;
+      const classification = classifyCheckpointOwner(lease, {
+        currentOwnerId: this.ownerId,
+        currentHostId: hostId,
+        currentHostname: this.hostname,
+        currentRuntimeScope: runtimeScope,
+        probePid: this.probePid,
+      });
+      if (classification === "stale") candidates.push({ ownerId: lease.ownerId });
+    }
+    let next = 0;
+    const worker = async () => {
+      while (next < candidates.length) {
+        const candidate = candidates[next++];
+        await cleanupStaleOwner(git, repository, candidate.ownerId, this.options.cleanupTimeoutMs);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(this.options.maxConcurrentOwners, candidates.length) }, worker),
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    const scans = [...this.scans];
+    if (scans.length > 0) {
+      await Promise.race([Promise.allSettled(scans), delay(this.options.shutdownWaitMs)]);
+    }
+    for (const { repository, git } of this.initialized.values()) {
+      const refs = await enumerateOwnerRefs(
+        git,
+        repository,
+        this.ownerId,
+        this.options.cleanupTimeoutMs,
+      );
+      if (!refs.ok || refs.refs.length !== 0) continue;
+      await rm(leasePath(repository, this.ownerId), { force: true }).catch(() => undefined);
+    }
+    this.initialized.clear();
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -2,11 +2,13 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
+import type { CheckpointOwnerRegistry } from "./checkpoint-owners.js";
 import type {
   FileCheckpointUnavailableReason,
   GitCheckpoint,
   GitRepository,
   GitRunner,
+  OwnershipMode,
   PendingGitCheckpoint,
   SessionReader,
 } from "./types.js";
@@ -22,8 +24,13 @@ export function checkpointNamespace(sessionId: string): string {
 function checkpointRefs(
   sessionId: string,
   checkpointId: string,
+  ownership: OwnershipMode,
+  ownerId?: string,
 ): { beforeRef: string; afterRef: string } {
-  const prefix = `${REF_ROOT}/${checkpointNamespace(sessionId)}/${checkpointId}`;
+  const prefix =
+    ownership === "v2" && ownerId
+      ? `${REF_ROOT}/v2/${ownerId}/${checkpointNamespace(sessionId)}/${checkpointId}`
+      : `${REF_ROOT}/${checkpointNamespace(sessionId)}/${checkpointId}`;
   return { beforeRef: `${prefix}/before`, afterRef: `${prefix}/after` };
 }
 
@@ -179,16 +186,17 @@ async function releaseRefBatch(
   git: GitRunner,
   refs: readonly Pick<RefRelease, "ref" | "expectedHash">[],
   repository?: GitRepository,
+  timeoutMs?: number,
 ): Promise<boolean> {
   if (refs.length === 0) return true;
   const input = refs.map(({ ref, expectedHash }) => `delete ${ref} ${expectedHash}`).join("\n");
-  const args = ["update-ref", "--stdin"];
   const options = repository
-    ? { env: { GIT_DIR: repository.commonDir }, stdin: `${input}\n` }
-    : { stdin: `${input}\n` };
+    ? { env: { GIT_DIR: repository.commonDir }, stdin: `${input}\n`, timeoutMs }
+    : { stdin: `${input}\n`, timeoutMs };
   try {
-    const result = await git(args, options);
+    const result = await git(["update-ref", "--stdin"], options);
     if (result.code === 0) return true;
+    if (result.error === "timeout") return false;
   } catch {
     // Retry smaller batches below.
   }
@@ -198,8 +206,8 @@ async function releaseRefBatch(
       : false;
   }
   const midpoint = Math.ceil(refs.length / 2);
-  const left = await releaseRefBatch(git, refs.slice(0, midpoint), repository);
-  const right = await releaseRefBatch(git, refs.slice(midpoint), repository);
+  const left = await releaseRefBatch(git, refs.slice(0, midpoint), repository, timeoutMs);
+  const right = await releaseRefBatch(git, refs.slice(midpoint), repository, timeoutMs);
   return left && right;
 }
 
@@ -294,10 +302,14 @@ export type FinishAfterTurnResult =
 export async function prepareBeforeTurn(
   git: GitRunner,
   sessionId: string,
+  ownerRegistry?: CheckpointOwnerRegistry,
 ): Promise<PrepareBeforeTurnResult> {
   const resolved = await resolveRepository(git);
   if ("reason" in resolved) return { status: "session_only", reason: resolved.reason };
 
+  const ownership = ownerRegistry
+    ? await ownerRegistry.ensureInitialized(resolved.repository, git)
+    : "legacy";
   const checkpointId = randomUUID();
   const snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn");
   if (!("hash" in snapshot)) {
@@ -306,7 +318,7 @@ export async function prepareBeforeTurn(
       reason: snapshot.reason === "invalid_head" ? "invalid_head" : "before_snapshot_failed",
     };
   }
-  const beforeRef = checkpointRefs(sessionId, checkpointId).beforeRef;
+  const { beforeRef } = checkpointRefs(sessionId, checkpointId, ownership, ownerRegistry?.ownerId);
   if (
     !(await run(git, [
       "update-ref",

--- a/src/core/git-runner.ts
+++ b/src/core/git-runner.ts
@@ -1,0 +1,135 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { promisify } from "node:util";
+import type { GitRunner } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+const TERMINATION_GRACE_MS = 250;
+
+type ChildResult = {
+  stdout: string;
+  stderr: string;
+  code: number;
+  error?: "unavailable" | "timeout";
+};
+
+export interface GitRunnerDependencies {
+  spawnGit?: typeof spawn;
+  terminationGraceMs?: number;
+}
+
+function runStdinCommand(
+  cwd: string,
+  args: string[],
+  options: NonNullable<Parameters<GitRunner>[1]>,
+  dependencies: GitRunnerDependencies,
+): Promise<ChildResult> {
+  let resolve!: (value: ChildResult) => void;
+  const promise = new Promise<ChildResult>((complete) => {
+    resolve = complete;
+  });
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = (dependencies.spawnGit ?? spawn)("git", args, {
+      cwd,
+      env: { ...process.env, ...options.env },
+      windowsHide: true,
+    });
+  } catch (error) {
+    resolve({
+      stdout: "",
+      stderr: error instanceof Error ? error.message : "",
+      code: 1,
+      error: "unavailable",
+    });
+    return promise;
+  }
+
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+  let timedOut = false;
+  let deadlineTimer: NodeJS.Timeout | undefined;
+  let graceTimer: NodeJS.Timeout | undefined;
+
+  const clearTimers = () => {
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+    if (graceTimer) clearTimeout(graceTimer);
+    deadlineTimer = undefined;
+    graceTimer = undefined;
+  };
+  const settle = (result: ChildResult) => {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    resolve(timedOut ? { ...result, error: "timeout" } : result);
+  };
+  const terminate = () => {
+    if (settled) return;
+    timedOut = true;
+    child.kill();
+    graceTimer = setTimeout(() => {
+      if (!settled) child.kill("SIGKILL");
+    }, dependencies.terminationGraceMs ?? TERMINATION_GRACE_MS);
+  };
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.once("error", (error: Error) => {
+    settle({
+      stdout,
+      stderr: `${stderr}${error.message}`,
+      code: 1,
+      error: timedOut ? "timeout" : "unavailable",
+    });
+  });
+  child.once("close", (code: number | null) => {
+    settle({ stdout, stderr, code: typeof code === "number" ? code : 1 });
+  });
+  child.stdin.on("error", () => {});
+  child.stdin.end(options.stdin);
+  if (options.timeoutMs !== undefined) {
+    deadlineTimer = setTimeout(terminate, Math.max(1, options.timeoutMs));
+  }
+  return promise;
+}
+
+export function createGitRunner(cwd: string, dependencies: GitRunnerDependencies = {}): GitRunner {
+  const runner: GitRunner = async (args, options) => {
+    if (options?.stdin !== undefined) return runStdinCommand(cwd, args, options, dependencies);
+    try {
+      const result = await execFileAsync("git", args, {
+        cwd,
+        env: { ...process.env, ...options?.env },
+        windowsHide: true,
+        timeout: options?.timeoutMs,
+      });
+      return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+    } catch (error) {
+      const failure = error as {
+        stdout?: string;
+        stderr?: string;
+        code?: number;
+        killed?: boolean;
+      };
+      const timedOut = options?.timeoutMs !== undefined && failure.killed === true;
+      return {
+        stdout: failure.stdout ?? "",
+        stderr: failure.stderr ?? "",
+        code: typeof failure.code === "number" ? failure.code : 1,
+        ...(timedOut
+          ? { error: "timeout" as const }
+          : typeof failure.code === "number"
+            ? {}
+            : { error: "unavailable" as const }),
+      };
+    }
+  };
+  runner.cwd = cwd;
+  return runner;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,17 +45,21 @@ export interface NavigationPort extends SessionReader {
 export interface GitRunOptions {
   env?: Record<string, string | undefined>;
   stdin?: string;
+  timeoutMs?: number;
 }
 
-export type GitRunner = ((
-  args: string[],
-  options?: GitRunOptions,
-) => Promise<{
+export type GitRunError = "unavailable" | "timeout";
+
+export type OwnershipMode = "v2" | "legacy";
+
+export type GitCommandResult = {
   stdout: string;
   stderr: string;
   code: number;
-  error?: "unavailable";
-}>) & {
+  error?: GitRunError;
+};
+
+export type GitRunner = ((args: string[], options?: GitRunOptions) => Promise<GitCommandResult>) & {
   cwd?: string;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
-import { execFile, spawn } from "node:child_process";
-import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
 import type { SessionEntryLike } from "./core/types.js";
 import { runRedo } from "./commands/redo.js";
 import { runUndo } from "./commands/undo.js";
+import {
+  CheckpointOwnerRegistry,
+  resolvePersistentHostId,
+  resolveRuntimeScope,
+} from "./core/checkpoint-owners.js";
+import { createGitRunner } from "./core/git-runner.js";
 import { SessionNavigation } from "./core/session-navigation.js";
 import {
   finishAfterTurn,
@@ -11,9 +15,7 @@ import {
   releaseCheckpoint,
   releasePendingCheckpoint,
 } from "./core/checkpoints.js";
-import type { GitRunner, PendingTurnCheckpoint, SessionOnlyCheckpoint } from "./core/types.js";
-
-const execFileAsync = promisify(execFile);
+import type { PendingTurnCheckpoint, SessionOnlyCheckpoint } from "./core/types.js";
 
 function promiseWithResolvers<T>(): {
   promise: Promise<T>;
@@ -38,75 +40,6 @@ type AnyContext = {
   };
 };
 
-function createGitRunner(cwd: string): GitRunner {
-  const runner: GitRunner = async (args, options) => {
-    if (options?.stdin !== undefined) {
-      const { promise, resolve } = promiseWithResolvers<{
-        stdout: string;
-        stderr: string;
-        code: number;
-        error?: "unavailable";
-      }>();
-      const child = spawn("git", args, {
-        cwd,
-        env: { ...process.env, ...options.env },
-        windowsHide: true,
-      });
-      let stdout = "";
-      let stderr = "";
-      let settled = false;
-      child.stdout.setEncoding("utf8");
-      child.stderr.setEncoding("utf8");
-      child.stdout.on("data", (chunk: string) => {
-        stdout += chunk;
-      });
-      child.stderr.on("data", (chunk: string) => {
-        stderr += chunk;
-      });
-      child.once("error", (error) => {
-        if (settled) return;
-        settled = true;
-        resolve({
-          stdout,
-          stderr: `${stderr}${error.message}`,
-          code: 1,
-          error: "unavailable",
-        });
-      });
-      child.once("close", (code) => {
-        if (settled) return;
-        settled = true;
-        resolve({ stdout, stderr, code: typeof code === "number" ? code : 1 });
-      });
-      child.stdin.on("error", () => {});
-      child.stdin.end(options.stdin);
-      return await promise;
-    }
-    try {
-      const result = await execFileAsync("git", args, {
-        cwd,
-        env: { ...process.env, ...options?.env },
-        windowsHide: true,
-      });
-      return { stdout: result.stdout, stderr: result.stderr, code: 0 };
-    } catch (error) {
-      const failure = error as {
-        stdout?: string;
-        stderr?: string;
-        code?: number;
-      };
-      return {
-        stdout: failure.stdout ?? "",
-        stderr: failure.stderr ?? "",
-        code: typeof failure.code === "number" ? failure.code : 1,
-        ...(typeof failure.code === "number" ? {} : { error: "unavailable" as const }),
-      };
-    }
-  };
-  runner.cwd = cwd;
-  return runner;
-}
-
 function createNavigation(ctx: AnyContext): SessionNavigation {
   const manager = ctx.sessionManager;
   return new SessionNavigation(
@@ -121,6 +54,10 @@ function createNavigation(ctx: AnyContext): SessionNavigation {
 }
 
 export default function ompUndoRedo(pi: ExtensionAPI): void {
+  const ownerRegistry = new CheckpointOwnerRegistry({
+    resolveHostIdentity: resolvePersistentHostId,
+    resolveRuntimeScope,
+  });
   const navigations = new Map<string, SessionNavigation>();
   const pending = new Map<string, PendingTurnCheckpoint>();
   const activeOperations = new Set<Promise<void>>();
@@ -253,7 +190,11 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
       pending.delete(sessionId);
       if (oldPending) await releasePending(oldPending);
 
-      const prepared = await prepareBeforeTurn(createGitRunner(typed.cwd), sessionId);
+      const prepared = await prepareBeforeTurn(
+        createGitRunner(typed.cwd),
+        sessionId,
+        ownerRegistry,
+      );
       const parentLeafId = typed.sessionManager.getLeafId();
       const checkpoint: PendingTurnCheckpoint =
         prepared.status === "git"
@@ -333,6 +274,7 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
       await disposeDetached(detachedNavigations, detachedPending);
       await Promise.allSettled([...activeOperations]);
       await drainState();
+      await ownerRegistry.shutdown();
     })();
     return shutdownPromise;
   });

--- a/test/checkpoint-owners.test.ts
+++ b/test/checkpoint-owners.test.ts
@@ -1,0 +1,444 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CheckpointOwnerRegistry,
+  classifyCheckpointOwner,
+  parseCheckpointOwnerLease,
+  parseCheckpointOwnerRef,
+  resolvePersistentHostId,
+  resolveRuntimeScope,
+} from "../src/core/checkpoint-owners.js";
+import { createGitRunner } from "../src/core/git-runner.js";
+import {
+  finishAfterTurn,
+  prepareBeforeTurn,
+  releasePendingCheckpoint,
+} from "../src/core/checkpoints.js";
+import { SessionNavigation } from "../src/core/session-navigation.js";
+import type { GitRepository, GitRunner, NavigationPort } from "../src/core/types.js";
+
+const ownerA = "11111111-1111-4111-8111-111111111111";
+const ownerB = "22222222-2222-4222-8222-222222222222";
+const hostA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const sessionHash = "a".repeat(64);
+const runtimeScope = "c".repeat(64);
+const checkpointId = "33333333-3333-4333-8333-333333333333";
+const objectHash = "b".repeat(40);
+
+function lease(ownerId: string, hostId = hostA, pid = 1234): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    ownerId,
+    hostId,
+    hostname: "test-host",
+    runtimeScope,
+    pid,
+    startedAt: "2026-07-31T00:00:00.000Z",
+  });
+}
+
+async function makeRepository(): Promise<{
+  cwd: string;
+  commonDir: string;
+  git: GitRunner;
+  repository: GitRepository;
+}> {
+  const cwd = await mkdtemp(join(tmpdir(), "omp-owner-repo-"));
+  const git = createGitRunner(cwd);
+  expect((await git(["init", "-q"])).code).toBe(0);
+  expect((await git(["config", "core.autocrlf", "false"])).code).toBe(0);
+  await writeFile(join(cwd, "tracked.txt"), "before\n");
+  expect((await git(["add", "tracked.txt"])).code).toBe(0);
+  expect(
+    (
+      await git([
+        "-c",
+        "user.name=owner-test",
+        "-c",
+        "user.email=owner-test@local",
+        "commit",
+        "-qm",
+        "base",
+      ])
+    ).code,
+  ).toBe(0);
+  const commonDirResult = await git(["rev-parse", "--git-common-dir"]);
+  expect(commonDirResult.code).toBe(0);
+  const commonDir = resolve(cwd, commonDirResult.stdout.trim());
+  return {
+    cwd,
+    commonDir,
+    git,
+    repository: { commonDir, gitDir: commonDir, worktree: cwd },
+  };
+}
+
+describe("checkpoint owner boundaries", () => {
+  it("accepts only canonical v2 refs and full object IDs", () => {
+    expect(
+      parseCheckpointOwnerRef(
+        `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`,
+      ),
+    ).toEqual({ ownerId: ownerA, sessionHash, checkpointId, phase: "before" });
+    expect(
+      parseCheckpointOwnerRef(`refs/omp-undo-redo/${sessionHash}/${checkpointId}/before`),
+    ).toBeNull();
+    expect(
+      parseCheckpointOwnerRef(
+        `refs/omp-undo-redo/v3/${ownerA}/${sessionHash}/${checkpointId}/before`,
+      ),
+    ).toBeNull();
+    expect(
+      parseCheckpointOwnerRef(`refs/omp-undo-redo/v2/${ownerA}/../${checkpointId}/before`),
+    ).toBeNull();
+  });
+
+  it("rejects malformed or mismatched lease metadata", () => {
+    expect(parseCheckpointOwnerLease(`${ownerA}.json`, lease(ownerB))).toBeNull();
+    expect(
+      parseCheckpointOwnerLease(
+        `${ownerA}.json`,
+        JSON.stringify({ ...JSON.parse(lease(ownerA)), extra: true }),
+      ),
+    ).toBeNull();
+    expect(
+      parseCheckpointOwnerLease(
+        `${ownerA}.json`,
+        JSON.stringify({ ...JSON.parse(lease(ownerA)), pid: 0 }),
+      ),
+    ).toBeNull();
+  });
+
+  it("deletes only a provably stale owner prefix", async () => {
+    const commonDir = await mkdtemp(join(tmpdir(), "omp-owner-test-"));
+    const repository: GitRepository = { commonDir, gitDir: commonDir, worktree: commonDir };
+    const ownersDir = join(commonDir, "omp-undo-redo", "owners");
+    await mkdir(ownersDir, { recursive: true });
+    await writeFile(join(ownersDir, `${ownerA}.json`), lease(ownerA, hostA, 9999));
+    await writeFile(join(ownersDir, `${ownerB}.json`), lease(ownerB, hostA, process.pid));
+    const refs = new Set([`refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`]);
+    const git: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: [...refs].map((ref) => `${ref}\0${objectHash}`).join("\n"),
+          stderr: "",
+          code: 0,
+        };
+      }
+      for (const ref of refs) refs.delete(ref);
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const registry = new CheckpointOwnerRegistry({
+      ownerId: ownerB,
+      hostIdentity: { id: hostA, persistent: true },
+      hostname: "test-host",
+      runtimeScope,
+      probePid: () => {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      },
+      shutdownWaitMs: 50,
+    });
+    expect(await registry.ensureInitialized(repository, git)).toBe("v2");
+    await registry.shutdown();
+    expect(refs.size).toBe(0);
+    await expect(readFile(join(ownersDir, `${ownerA}.json`), "utf8")).rejects.toThrow();
+    await expect(readFile(join(ownersDir, `${ownerB}.json`), "utf8")).rejects.toThrow();
+    expect(await readdir(ownersDir)).not.toContain(`${ownerB}.json`);
+  });
+
+  it("preserves a live foreign owner with real Git", async () => {
+    const { cwd, commonDir, git, repository } = await makeRepository();
+    const ownersDir = join(commonDir, "omp-undo-redo", "owners");
+    const liveRef = `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`;
+    try {
+      await mkdir(ownersDir, { recursive: true });
+      await writeFile(join(ownersDir, `${ownerA}.json`), lease(ownerA, hostA, process.pid));
+      expect((await git(["update-ref", liveRef, "HEAD"])).code).toBe(0);
+      const registry = new CheckpointOwnerRegistry({
+        ownerId: ownerB,
+        hostIdentity: { id: hostA, persistent: true },
+        hostname: "test-host",
+        runtimeScope,
+        shutdownWaitMs: 1_000,
+      });
+
+      expect(await registry.ensureInitialized(repository, git)).toBe("v2");
+      await registry.shutdown();
+
+      expect((await git(["show-ref", "--verify", liveRef])).code).toBe(0);
+      expect(await readFile(join(ownersDir, `${ownerA}.json`), "utf8")).toContain(ownerA);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves changed refs and their stale-owner lease", async () => {
+    const commonDir = await mkdtemp(join(tmpdir(), "omp-owner-mismatch-"));
+    const repository: GitRepository = { commonDir, gitDir: commonDir, worktree: commonDir };
+    const ownersDir = join(commonDir, "omp-undo-redo", "owners");
+    const changedRef = `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`;
+    await mkdir(ownersDir, { recursive: true });
+    await writeFile(join(ownersDir, `${ownerA}.json`), lease(ownerA, hostA, 9999));
+    const git: GitRunner = async (args) =>
+      args[0] === "for-each-ref"
+        ? { stdout: `${changedRef}\0${objectHash}\n`, stderr: "", code: 0 }
+        : { stdout: "", stderr: "compare failed", code: 1 };
+    const registry = new CheckpointOwnerRegistry({
+      ownerId: ownerB,
+      hostIdentity: { id: hostA, persistent: true },
+      hostname: "test-host",
+      runtimeScope,
+      probePid: () => {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      },
+      shutdownWaitMs: 1_000,
+    });
+
+    expect(await registry.ensureInitialized(repository, git)).toBe("v2");
+    await registry.shutdown();
+
+    expect(await readFile(join(ownersDir, `${ownerA}.json`), "utf8")).toContain(ownerA);
+    await rm(commonDir, { recursive: true, force: true });
+  });
+
+  it("does not split or retry a timed-out stale deletion", async () => {
+    const commonDir = await mkdtemp(join(tmpdir(), "omp-owner-timeout-"));
+    const repository: GitRepository = { commonDir, gitDir: commonDir, worktree: commonDir };
+    const ownersDir = join(commonDir, "omp-undo-redo", "owners");
+    const refs = [
+      `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`,
+      `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/after`,
+    ];
+    await mkdir(ownersDir, { recursive: true });
+    await writeFile(join(ownersDir, `${ownerA}.json`), lease(ownerA, hostA, 9999));
+    let updateCalls = 0;
+    const git: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: refs.map((ref) => `${ref}\0${objectHash}`).join("\n"),
+          stderr: "",
+          code: 0,
+        };
+      }
+      updateCalls++;
+      return { stdout: "", stderr: "timed out", code: 1, error: "timeout" };
+    };
+    const registry = new CheckpointOwnerRegistry({
+      ownerId: ownerB,
+      hostIdentity: { id: hostA, persistent: true },
+      hostname: "test-host",
+      runtimeScope,
+      probePid: () => {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      },
+      shutdownWaitMs: 1_000,
+    });
+
+    expect(await registry.ensureInitialized(repository, git)).toBe("v2");
+    await registry.shutdown();
+
+    expect(updateCalls).toBe(1);
+    expect(await readFile(join(ownersDir, `${ownerA}.json`), "utf8")).toContain(ownerA);
+    await rm(commonDir, { recursive: true, force: true });
+  });
+
+  it("reaps only v2 owner refs and preserves legacy and future versions", async () => {
+    const { cwd, commonDir, git, repository } = await makeRepository();
+    const ownersDir = join(commonDir, "omp-undo-redo", "owners");
+    const staleV2 = `refs/omp-undo-redo/v2/${ownerA}/${sessionHash}/${checkpointId}/before`;
+    const legacy = `refs/omp-undo-redo/${sessionHash}/${checkpointId}/before`;
+    const future = `refs/omp-undo-redo/v3/${ownerA}/${sessionHash}/${checkpointId}/before`;
+    try {
+      await mkdir(ownersDir, { recursive: true });
+      await writeFile(join(ownersDir, `${ownerA}.json`), lease(ownerA, hostA, 9999));
+      for (const ref of [staleV2, legacy, future]) {
+        expect((await git(["update-ref", ref, "HEAD"])).code).toBe(0);
+      }
+      const registry = new CheckpointOwnerRegistry({
+        ownerId: ownerB,
+        hostIdentity: { id: hostA, persistent: true },
+        hostname: "test-host",
+        runtimeScope,
+        probePid: () => {
+          throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        },
+        shutdownWaitMs: 1_000,
+      });
+
+      expect(await registry.ensureInitialized(repository, git)).toBe("v2");
+      await registry.shutdown();
+
+      expect((await git(["show-ref", "--verify", staleV2])).code).not.toBe(0);
+      expect((await git(["show-ref", "--verify", legacy])).code).toBe(0);
+      expect((await git(["show-ref", "--verify", future])).code).toBe(0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("falls back to legacy refs when lease publication fails", async () => {
+    const { cwd, commonDir, git } = await makeRepository();
+    try {
+      await writeFile(join(commonDir, "omp-undo-redo"), "block owner directory");
+      const registry = new CheckpointOwnerRegistry({
+        ownerId: ownerB,
+        hostIdentity: { id: hostA, persistent: true },
+        hostname: "test-host",
+        runtimeScope,
+      });
+
+      const prepared = await prepareBeforeTurn(git, "legacy-fallback", registry);
+      expect(prepared.status).toBe("git");
+      if (prepared.status !== "git") return;
+      expect(prepared.checkpoint.beforeRef).not.toContain("/v2/");
+      expect(await releasePendingCheckpoint(git, prepared.checkpoint)).toBe(true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a live owner's checkpoints usable for undo and redo during another scan", async () => {
+    const { cwd, git, repository } = await makeRepository();
+    const ownerRegistry = new CheckpointOwnerRegistry({
+      ownerId: ownerA,
+      hostIdentity: { id: hostA, persistent: true },
+      hostname: "test-host",
+      runtimeScope,
+    });
+    try {
+      const prepared = await prepareBeforeTurn(git, "live-navigation", ownerRegistry);
+      expect(prepared.status).toBe("git");
+      if (prepared.status !== "git") return;
+      await writeFile(join(cwd, "tracked.txt"), "after\n");
+      const finished = await finishAfterTurn(git, prepared.checkpoint, "parent", "leaf");
+      expect(finished.status).toBe("git");
+      if (finished.status !== "git") return;
+
+      const scanner = new CheckpointOwnerRegistry({
+        ownerId: ownerB,
+        hostIdentity: { id: hostA, persistent: true },
+        hostname: "test-host",
+        runtimeScope,
+        shutdownWaitMs: 1_000,
+      });
+      expect(await scanner.ensureInitialized(repository, git)).toBe("v2");
+      await scanner.shutdown();
+
+      let leaf = "leaf";
+      const port: NavigationPort = {
+        getLeafId: () => leaf,
+        getBranch: () => [],
+        getEntry: () => undefined,
+        navigateTree: async (targetId) => {
+          leaf = targetId;
+          return { cancelled: false };
+        },
+      };
+      const navigation = new SessionNavigation(port, git);
+      await navigation.recordTurnEnd(finished.checkpoint);
+
+      expect(await navigation.undo()).toEqual({ status: "moved", files: "restored" });
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("before\n");
+      expect(await navigation.redo()).toEqual({ status: "moved", files: "restored" });
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("after\n");
+      await navigation.dispose();
+    } finally {
+      await ownerRegistry.shutdown();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("owner liveness", () => {
+  it("preserves current, remote, and uncertain owners", () => {
+    const current = parseCheckpointOwnerLease(`${ownerA}.json`, lease(ownerA));
+    const remote = parseCheckpointOwnerLease(
+      `${ownerB}.json`,
+      lease(ownerB, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+    );
+    const otherScope = parseCheckpointOwnerLease(
+      `${ownerB}.json`,
+      JSON.stringify({ ...JSON.parse(lease(ownerB)), runtimeScope: "d".repeat(64) }),
+    );
+    expect(
+      current &&
+        classifyCheckpointOwner(current, {
+          currentOwnerId: ownerA,
+          currentHostId: hostA,
+          currentHostname: "test-host",
+          currentRuntimeScope: runtimeScope,
+        }),
+    ).toBe("alive");
+    expect(
+      remote &&
+        classifyCheckpointOwner(remote, {
+          currentOwnerId: ownerA,
+          currentHostId: hostA,
+          currentHostname: "test-host",
+          currentRuntimeScope: runtimeScope,
+        }),
+    ).toBe("remote");
+    expect(
+      otherScope &&
+        classifyCheckpointOwner(otherScope, {
+          currentOwnerId: ownerA,
+          currentHostId: hostA,
+          currentHostname: "test-host",
+          currentRuntimeScope: runtimeScope,
+          probePid: () => {
+            throw new Error("a foreign runtime scope must not be probed");
+          },
+        }),
+    ).toBe("remote");
+    expect(
+      remote &&
+        classifyCheckpointOwner(remote, {
+          currentOwnerId: ownerA,
+          currentHostId: hostA,
+          currentHostname: "test-host",
+          currentRuntimeScope: null,
+        }),
+    ).toBe("unknown");
+  });
+
+  it("reuses a persistent host ID and does not overwrite malformed state", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omp-host-test-"));
+    const first = await resolvePersistentHostId({
+      platform: "linux",
+      homeDirectory: home,
+      randomId: () => hostA,
+    });
+    const second = await resolvePersistentHostId({
+      platform: "linux",
+      homeDirectory: home,
+      randomId: () => ownerA,
+    });
+    expect(first).toEqual({ id: hostA, persistent: true });
+    expect(second).toEqual(first);
+  });
+
+  it("binds Linux cleanup to both boot and PID namespace identity", async () => {
+    const first = await resolveRuntimeScope({
+      platform: "linux",
+      readFile: async () => "11111111-1111-4111-8111-111111111111\n",
+      readlink: async () => "pid:[4026531836]",
+    });
+    const otherNamespace = await resolveRuntimeScope({
+      platform: "linux",
+      readFile: async () => "11111111-1111-4111-8111-111111111111\n",
+      readlink: async () => "pid:[4026532999]",
+    });
+    const unavailable = await resolveRuntimeScope({
+      platform: "linux",
+      readFile: async () => {
+        throw new Error("unavailable");
+      },
+      readlink: async () => "pid:[4026531836]",
+    });
+
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(otherNamespace).not.toBe(first);
+    expect(unavailable).toBeNull();
+  });
+});

--- a/test/git-runner.test.ts
+++ b/test/git-runner.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from "node:events";
+import type { spawn as Spawn } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGitRunner } from "../src/core/git-runner.js";
+
+async function runnerInTempRepo() {
+  const cwd = await mkdtemp(join(tmpdir(), "omp-runner-test-"));
+  const git = createGitRunner(cwd);
+  await git(["init", "-q"]);
+  return git;
+}
+
+class FakeGitChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin = new PassThrough();
+  readonly signals: string[] = [];
+
+  kill(signal = "SIGTERM"): boolean {
+    this.signals.push(signal);
+    return true;
+  }
+}
+
+function runnerWithChild(child: FakeGitChild, terminationGraceMs = 50) {
+  const spawnGit = (() => child) as unknown as typeof Spawn;
+  return createGitRunner(".", { spawnGit, terminationGraceMs });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Git runner", () => {
+  it("preserves ordinary Git failures", async () => {
+    const git = await runnerInTempRepo();
+    const result = await git(["show-ref", "--verify", "refs/heads/missing"]);
+    expect(result.code).not.toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("settles stdin commands after Git closes", async () => {
+    const git = await runnerInTempRepo();
+    const result = await git(["update-ref", "--stdin"], {
+      stdin: "start\n",
+      timeoutMs: 1_000,
+    });
+    expect(result.code).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("waits for close after timeout and force-kills after the grace period", async () => {
+    vi.useFakeTimers();
+    const child = new FakeGitChild();
+    const resultPromise = runnerWithChild(child)(["update-ref", "--stdin"], {
+      stdin: "start\n",
+      timeoutMs: 100,
+    });
+    let settled = false;
+    void resultPromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(child.signals).toEqual(["SIGTERM"]);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(settled).toBe(false);
+
+    child.emit("close", null);
+    await expect(resultPromise).resolves.toMatchObject({ code: 1, error: "timeout" });
+  });
+
+  it("does not force-kill when close arrives during the grace period", async () => {
+    vi.useFakeTimers();
+    const child = new FakeGitChild();
+    const resultPromise = runnerWithChild(child)(["update-ref", "--stdin"], {
+      stdin: "",
+      timeoutMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    child.emit("close", 0);
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(child.signals).toEqual(["SIGTERM"]);
+    await expect(resultPromise).resolves.toMatchObject({ code: 0, error: "timeout" });
+  });
+
+  it("settles once when error and close race after timeout", async () => {
+    vi.useFakeTimers();
+    const child = new FakeGitChild();
+    const resultPromise = runnerWithChild(child)(["update-ref", "--stdin"], {
+      stdin: "",
+      timeoutMs: 100,
+    });
+    const observer = vi.fn();
+    void resultPromise.then(observer);
+
+    await vi.advanceTimersByTimeAsync(100);
+    child.emit("error", new Error("terminated"));
+    child.emit("close", 1);
+    await resultPromise;
+
+    expect(observer).toHaveBeenCalledTimes(1);
+    await expect(resultPromise).resolves.toMatchObject({ error: "timeout" });
+  });
+
+  it("classifies synchronous spawn failure as unavailable", async () => {
+    const spawnGit = (() => {
+      throw new Error("missing");
+    }) as unknown as typeof Spawn;
+    const git = createGitRunner(".", { spawnGit });
+
+    await expect(git(["update-ref", "--stdin"], { stdin: "" })).resolves.toMatchObject({
+      code: 1,
+      error: "unavailable",
+    });
+  });
+});

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -169,6 +169,8 @@ describe("session-only lifecycle fallback", () => {
         "Undid last turn: session moved back and worktree snapshot restored; Git index left unchanged.",
       );
       expect(await privateRefs(cwd)).toHaveLength(2);
+      const refs = await privateRefs(cwd);
+      expect(refs.every((ref) => ref.startsWith("refs/omp-undo-redo/v2/"))).toBe(true);
       await pi.runCommand("redo", ctx);
       await expect(readFile(join(cwd, "tracked.txt"), "utf8")).resolves.toBe("changed\n");
       expect(ctx.ui.notifications.at(-1)?.message).toBe(


### PR DESCRIPTION
## Summary\n- add owner-scoped v2 checkpoint refs and repository leases\n- reap only provably stale same-host owners with bounded compare-and-delete cleanup\n- preserve legacy fallback and existing undo/redo behavior\n- document ownership limitations and release v1.0.29\n\n## Verification\n- npm run verify\n- manual scenarios A-F completed on Windows\n- SHA-256 and linked-worktree smoke checks passed