### PR TITLE
fix: serialize overlapping undo and redo navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.0.30] - 2026-07-31
+
+### Fixed
+
+- Serialize overlapping undo and redo operations so each command advances exactly one checkpoint without corrupting the history position.
+
 ## [1.0.29] - 2026-07-31
 
 ### Added
@@ -203,6 +209,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
+[1.0.30]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.30
 [1.0.26]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.26
 [1.0.25]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.25
 [1.0.24]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/core/session-navigation.ts
+++ b/src/core/session-navigation.ts
@@ -24,6 +24,7 @@ export class SessionNavigation {
   private navigateTree: NavigationPort["navigateTree"] = async () => ({ cancelled: true });
   private expectedTreeNavigation: ExpectedTreeNavigation | null = null;
   private readonly gitForRepository: GitRunnerFactory;
+  private navigationTail: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly port: Omit<NavigationPort, "navigateTree"> & {
@@ -38,6 +39,15 @@ export class SessionNavigation {
 
   setNavigateTree(navigateTree: NavigationPort["navigateTree"]): void {
     this.navigateTree = navigateTree;
+  }
+
+  private serializeNavigation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.navigationTail.then(operation);
+    this.navigationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private async navigateTo(targetId: string): Promise<TreeNavigationResult> {
@@ -125,7 +135,11 @@ export class SessionNavigation {
     return { status: "moved", files: "unavailable", reason: checkpoint.reason };
   }
 
-  async undo(): Promise<NavigationResult> {
+  undo(): Promise<NavigationResult> {
+    return this.serializeNavigation(() => this.performUndo());
+  }
+
+  private async performUndo(): Promise<NavigationResult> {
     if (this.currentIndex < 0) return { status: "empty" };
     const checkpoint = this.checkpoints[this.currentIndex];
     if (checkpoint.kind === "session") {
@@ -148,7 +162,11 @@ export class SessionNavigation {
     return { status: "moved", files: "restored" };
   }
 
-  async redo(): Promise<NavigationResult> {
+  redo(): Promise<NavigationResult> {
+    return this.serializeNavigation(() => this.performRedo());
+  }
+
+  private async performRedo(): Promise<NavigationResult> {
     if (this.currentIndex >= this.checkpoints.length - 1) return { status: "empty" };
     const checkpoint = this.checkpoints[this.currentIndex + 1];
     if (checkpoint.kind === "session") {

--- a/test/command-behavior.test.ts
+++ b/test/command-behavior.test.ts
@@ -110,6 +110,25 @@ describe("session navigation", () => {
     expect((await navigation.redo()).status).toBe("empty");
   });
 
+  it("serializes overlapping undo and redo operations", async () => {
+    const session = port();
+    const navigation = makeNavigation(session);
+    await navigation.recordTurnEnd(sessionCheckpoint("u1", "a1"));
+    await navigation.recordTurnEnd(sessionCheckpoint("u2", "a2"));
+
+    const undoResults = await Promise.all([navigation.undo(), navigation.undo()]);
+    expect(undoResults.map((result) => result.status)).toEqual(["moved", "moved"]);
+    expect(session.navigateCalls).toEqual(["u2", "u1"]);
+    expect(session.leaf).toBe("u1");
+    expect((await navigation.undo()).status).toBe("empty");
+
+    const redoResults = await Promise.all([navigation.redo(), navigation.redo()]);
+    expect(redoResults.map((result) => result.status)).toEqual(["moved", "moved"]);
+    expect(session.navigateCalls).toEqual(["u2", "u1", "a1", "a2"]);
+    expect(session.leaf).toBe("a2");
+    expect((await navigation.redo()).status).toBe("empty");
+  });
+
   it("preserves redo for matching internal tree navigation", async () => {
     const session = port();
     const navigation = makeNavigation(session);


### PR DESCRIPTION
## Summary\n- serialize overlapping undo and redo operations\n- add regression coverage for concurrent navigation\n- release package version 1.0.30\n\n## Verification\n- npm run verify