### PR TITLE
fix: ignore trailing session exit entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
-## [1.0.31] - 2026-07-31
+## [1.0.32] - 2026-07-31
 
 ### Added
 
@@ -13,6 +13,10 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
 - Retain completed checkpoints on graceful shutdown while continuing to release interrupted pending checkpoints.
 - Replace the misleading pre-turn warning with state-specific empty-history and closing-session messages.
+
+### Fixed
+
+- Ignore OMP's trailing `session_exit` diagnostic entry when validating resumed history, so quitting with Ctrl+C does not downgrade a valid Git checkpoint to session-only undo.
 
 ## [1.0.30] - 2026-07-31
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",

--- a/src/core/history-store.ts
+++ b/src/core/history-store.ts
@@ -9,6 +9,7 @@ import type {
   GitRunner,
   NavigationState,
   SessionReader,
+  SessionEntryLike,
   TurnCheckpoint,
 } from "./types.js";
 
@@ -155,6 +156,22 @@ function entryExists(reader: SessionReader, id: string | null): boolean {
   return id === null || reader.getEntry(id) !== undefined;
 }
 
+function isSessionExitEntry(entry: SessionEntryLike | undefined): boolean {
+  return entry?.type === "custom" && entry.customType === "session_exit";
+}
+
+function effectiveLeaf(reader: SessionReader): string | null {
+  let leafId = reader.getLeafId();
+  const visited = new Set<string>();
+  while (leafId && !visited.has(leafId)) {
+    visited.add(leafId);
+    const entry = reader.getEntry(leafId);
+    if (!isSessionExitEntry(entry)) return leafId;
+    leafId = entry?.parentId ?? null;
+  }
+  return leafId;
+}
+
 function expectedLeaf(state: NavigationState): string | null {
   if (state.checkpoints.length === 0) return null;
   return state.currentIndex >= 0
@@ -163,7 +180,9 @@ function expectedLeaf(state: NavigationState): string | null {
 }
 
 export function reconstructSessionHistory(reader: SessionReader): NavigationState {
-  const branch = reader.getBranch(reader.getLeafId() ?? undefined);
+  const branch = reader
+    .getBranch(reader.getLeafId() ?? undefined)
+    .filter((entry) => !isSessionExitEntry(entry));
   const checkpoints: TurnCheckpoint[] = [];
   for (let index = 0; index < branch.length; index++) {
     const entry = branch[index];
@@ -230,7 +249,7 @@ export class SessionHistoryStore {
             !entryExists(reader, checkpoint.parentLeafId) ||
             !entryExists(reader, checkpoint.leafId),
         ) ||
-        expectedLeaf(state) !== reader.getLeafId()
+        expectedLeaf(state) !== effectiveLeaf(reader)
       )
         return null;
       return state;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,7 @@ export interface SessionEntryLike {
   parentId: string | null;
   type: string;
   message?: { role?: string };
+  customType?: string;
 }
 
 export interface SessionReader {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -14,6 +14,7 @@ type TestEntry = {
   parentId: string | null;
   type: string;
   message?: { role?: string };
+  customType?: string;
 };
 
 type TestContext = {
@@ -354,6 +355,18 @@ describe("resumed session history", () => {
       type: "message",
       message: { role: "assistant" },
     };
+    const firstExit: TestEntry = {
+      id: "first-exit",
+      parentId: response.id,
+      type: "custom",
+      customType: "session_exit",
+    };
+    const secondExit: TestEntry = {
+      id: "second-exit",
+      parentId: prompt.id,
+      type: "custom",
+      customType: "session_exit",
+    };
     try {
       const firstApi = new FakeExtensionApi();
       ompUndoRedo(firstApi as never);
@@ -373,9 +386,9 @@ describe("resumed session history", () => {
       const secondApi = new FakeExtensionApi();
       ompUndoRedo(secondApi as never);
       const second = context(cwd, sessionId);
-      second.leaf = response.id;
-      second.branch = [prompt, response];
-      second.entries = [prompt, response];
+      second.leaf = firstExit.id;
+      second.branch = [prompt, response, firstExit];
+      second.entries = [prompt, response, firstExit];
       second.navigateTree = async (targetId) => {
         second.leaf = targetId;
         second.branch = targetId === prompt.id ? [prompt] : [prompt, response];
@@ -384,7 +397,7 @@ describe("resumed session history", () => {
       await secondApi.emit("session_start", second);
       await writeFile(join(cwd, "tracked.txt"), "manual\n");
       await secondApi.runCommand("undo", second);
-      expect(second.leaf).toBe(response.id);
+      expect(second.leaf).toBe(firstExit.id);
       expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("manual\n");
       expect(second.ui.notifications.at(-1)?.message).toBe("Worktree changed; nothing was undone.");
       await writeFile(join(cwd, "tracked.txt"), "changed\n");
@@ -396,9 +409,9 @@ describe("resumed session history", () => {
       const thirdApi = new FakeExtensionApi();
       ompUndoRedo(thirdApi as never);
       const third = context(cwd, sessionId);
-      third.leaf = prompt.id;
-      third.branch = [prompt];
-      third.entries = [prompt, response];
+      third.leaf = secondExit.id;
+      third.branch = [prompt, secondExit];
+      third.entries = [prompt, response, firstExit, secondExit];
       third.navigateTree = async (targetId) => {
         third.leaf = targetId;
         third.branch = targetId === prompt.id ? [prompt] : [prompt, response];


### PR DESCRIPTION
## Summary\n- Ignore trailing OMP session_exit diagnostic entries when validating resumed history.\n- Preserve resumable Git checkpoints across graceful shutdown and runtime restart.\n- Release package version 1.0.32.\n\n## Verification\n- npm run verify