### PR TITLE
chore: prepare Pi catalog release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.2.1] - 2026-08-06
+
+### Changed
+
+- Add Pi catalog discovery keywords and publish metadata for the package gallery.
+- Update pinned installation examples to version 1.2.1.
+
 ## [1.2.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.0.23
+omp plugin install @baylarsadigov/omp-undo-redo@1.2.1
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -61,7 +61,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.0.23
+pi install npm:@baylarsadigov/omp-undo-redo@1.2.1
 ```
 
 To update installed Pi packages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Undo and redo session navigation for Oh My Pi",
   "license": "MIT",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "undo",
+    "redo"
+  ],
   "homepage": "https://github.com/Baylar55/omp-undo-redo#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary\n- Add pi-package discovery keywords for pi.dev package search.\n- Bump package metadata to 1.2.1 and update lockfile.\n- Update pinned install examples and changelog.\n\n## Verification\n- npm run verify\n\nNo runtime source changes.