### PR TITLE
fix: protect skipped snapshot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.2.2] - 2026-08-07
+
+### Fixed
+
+- Keep skipped non-Git snapshot paths and overlapping parents or descendants untouched during partial undo and redo, preventing uncaptured files from being deleted.
+- Reject pre-upgrade in-flight journals whose recorded mutations overlap skipped paths rather than replaying an unsafe deletion.
+
 ## [1.2.1] - 2026-08-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.2.1
+omp plugin install @baylarsadigov/omp-undo-redo@1.2.2
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -61,7 +61,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.2.1
+pi install npm:@baylarsadigov/omp-undo-redo@1.2.2
 ```
 
 To update installed Pi packages:
@@ -82,7 +82,7 @@ The extension exposes exactly these commands:
 Commands take no arguments. They navigate OMP's session tree through the official extension API and do not create a new model turn.
 Both commands wait for the current agent turn to become idle; if OMP remains busy, the command leaves the session unchanged and shows a warning.
 
-Every completed turn remains navigable, including conversation-only turns and turns that change only ignored files. In Git projects, `/undo` and `/redo` restore worktree snapshots without rewriting the Git index. In non-Git workspaces, the built-in snapshot store restores regular files, binary content, and executable modes. Unsupported symlinks and files above the 16 MiB limit are reported as partial restoration. If checkpoint creation fails, commands navigate session context only and report that limitation. Such a session-only checkpoint is a file-history continuity barrier: older file checkpoints are discarded because applying them across an unknown file delta would be unsafe.
+Every completed turn remains navigable, including conversation-only turns and turns that change only ignored files. In Git projects, `/undo` and `/redo` restore worktree snapshots without rewriting the Git index. In non-Git workspaces, the built-in snapshot store restores regular files, binary content, and executable modes. Unsupported symlinks and files above the 16 MiB limit are reported as partial restoration. Skipped paths and their overlapping parent or descendant paths remain untouched during partial restoration. Such a session-only checkpoint is a file-history continuity barrier: older file checkpoints are discarded because applying them across an unknown file delta would be unsafe.
 
 Completed Git or non-Git checkpoints and the undo/redo cursor survive a normal terminal restart. Resuming the same session in the same worktree restores both `/undo` and `/redo` history. If durable file metadata is missing or unusable, the extension reconstructs completed turns from the active session branch and offers session-only undo with an explicit warning. A changed worktree must still pass the normal conflict check; resuming never bypasses file-safety checks.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.1",
-  "description": "Undo and redo session navigation for Oh My Pi",
+  "version": "1.2.2",
+  "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [
     "pi-package",

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -332,7 +332,12 @@ export class BlobStore {
         }
         const sourceMap = new Map(source.entries.map((entry) => [entry.path, entry]));
         const targetMap = new Map(target.entries.map((entry) => [entry.path, entry]));
-        const expectedPaths = this.changedPaths(sourceMap, targetMap);
+        const expectedPaths = this.changedPaths(
+          sourceMap,
+          targetMap,
+          source.skippedPaths,
+          target.skippedPaths,
+        );
         if (
           expectedPaths.length !== journalPaths.length ||
           expectedPaths.some((path, index) => path !== [...journalPaths].sort()[index])
@@ -359,8 +364,32 @@ export class BlobStore {
     await rename(journalPath, join(failedDirectory, basename(journalPath))).catch(() => undefined);
   }
 
-  private changedPaths(source: Map<string, TreeEntry>, target: Map<string, TreeEntry>): string[] {
+  private changedPaths(
+    source: Map<string, TreeEntry>,
+    target: Map<string, TreeEntry>,
+    sourceSkipped: readonly string[] = [],
+    targetSkipped: readonly string[] = [],
+  ): string[] {
+    const skipped = new Set([...sourceSkipped, ...targetSkipped]);
+    const skippedAndAncestors = new Set<string>();
+    for (const skippedPath of skipped) {
+      let current = skippedPath;
+      while (current !== "." && current !== "") {
+        skippedAndAncestors.add(current);
+        current = dirname(current);
+      }
+    }
+    const overlapsSkipped = (path: string): boolean => {
+      if (skippedAndAncestors.has(path)) return true;
+      let current = dirname(path);
+      while (current !== "." && current !== "") {
+        if (skipped.has(current)) return true;
+        current = dirname(current);
+      }
+      return false;
+    };
     return [...new Set([...source.keys(), ...target.keys()])]
+      .filter((path) => !overlapsSkipped(path))
       .filter((path) => {
         const left = source.get(path);
         const right = target.get(path);
@@ -602,7 +631,12 @@ export class BlobStore {
           for (const entry of source.entries) {
             if (!(await this.blobExists(entry.blobHash))) return { status: "failed" };
           }
-          const mutations = this.changedPaths(sourceMap, targetMap);
+          const mutations = this.changedPaths(
+            sourceMap,
+            targetMap,
+            source.skippedPaths,
+            target.skippedPaths,
+          );
 
           for (const path of mutations) {
             if (!this.validPath(path)) return { status: "conflict" };

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -231,6 +231,84 @@ describe("non-Git blob store", () => {
     await store.shutdown();
   });
 
+  it("leaves skipped-to-captured paths untouched while restoring safe paths", async () => {
+    const workspace = await temporaryDirectory("omp-blob-skipped-transition-workspace-");
+    const storage = await temporaryDirectory("omp-blob-skipped-transition-storage-");
+    const store = new BlobStore(storage, { maxFileBytes: 3 });
+    const session = sessionHash("skipped-transition");
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "changing.bin"), "1234");
+    await writeFile(join(workspace, "safe.txt"), "old");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    await writeFile(join(workspace, "changing.bin"), "ok");
+    await writeFile(join(workspace, "safe.txt"), "new");
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    expect(before.skippedPaths).toEqual(["changing.bin"]);
+    expect(after.skippedPaths).toEqual([]);
+
+    expect(await store.applySnapshot(workspace, session, after.treeId, before.treeId)).toEqual({
+      status: "applied",
+      partial: true,
+    });
+    await expect(readFile(join(workspace, "changing.bin"), "utf8")).resolves.toBe("ok");
+    await expect(readFile(join(workspace, "safe.txt"), "utf8")).resolves.toBe("old");
+    await store.shutdown();
+  });
+
+  it("leaves captured-to-skipped paths untouched while restoring safe paths", async () => {
+    const workspace = await temporaryDirectory("omp-blob-reverse-skipped-workspace-");
+    const storage = await temporaryDirectory("omp-blob-reverse-skipped-storage-");
+    const store = new BlobStore(storage, { maxFileBytes: 3 });
+    const session = sessionHash("reverse-skipped-transition");
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "changing.bin"), "ok");
+    await writeFile(join(workspace, "safe.txt"), "old");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    await writeFile(join(workspace, "changing.bin"), "1234");
+    await writeFile(join(workspace, "safe.txt"), "new");
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    expect(before.skippedPaths).toEqual([]);
+    expect(after.skippedPaths).toEqual(["changing.bin"]);
+
+    expect(await store.applySnapshot(workspace, session, after.treeId, before.treeId)).toEqual({
+      status: "applied",
+      partial: true,
+    });
+    await expect(readFile(join(workspace, "changing.bin"), "utf8")).resolves.toBe("1234");
+    await expect(readFile(join(workspace, "safe.txt"), "utf8")).resolves.toBe("old");
+    await store.shutdown();
+  });
+
+  it("protects ancestors and descendants of skipped paths", async () => {
+    const workspace = await temporaryDirectory("omp-blob-skipped-namespace-workspace-");
+    const storage = await temporaryDirectory("omp-blob-skipped-namespace-storage-");
+    const store = new BlobStore(storage, { maxFileBytes: 3 });
+    const session = sessionHash("skipped-namespace");
+    const checkpoint = randomUUID();
+    await mkdir(join(workspace, "ancestor"));
+    await writeFile(join(workspace, "ancestor", "large.bin"), "1234");
+    await writeFile(join(workspace, "descendant"), "1234");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    await rm(join(workspace, "ancestor"), { recursive: true });
+    await writeFile(join(workspace, "ancestor"), "ok");
+    await rm(join(workspace, "descendant"));
+    await mkdir(join(workspace, "descendant"));
+    await writeFile(join(workspace, "descendant", "child.txt"), "ok");
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    expect(before.skippedPaths).toEqual(["ancestor/large.bin", "descendant"]);
+
+    expect(await store.applySnapshot(workspace, session, after.treeId, before.treeId)).toEqual({
+      status: "applied",
+      partial: true,
+    });
+    await expect(readFile(join(workspace, "ancestor"), "utf8")).resolves.toBe("ok");
+    await expect(readFile(join(workspace, "descendant", "child.txt"), "utf8")).resolves.toBe("ok");
+    await store.shutdown();
+  });
+
   it("does not split refs when history promotion fails", async () => {
     const workspace = await temporaryDirectory("omp-blob-promotion-workspace-");
     const storage = await temporaryDirectory("omp-blob-promotion-storage-");


### PR DESCRIPTION
## Summary
- preserve skipped non-Git snapshot paths and overlapping namespaces during partial undo/redo
- reject unsafe pre-upgrade journals
- release package as 1.2.2 with updated docs and changelog

## Verification
- npm run verify