### PR TITLE
fix: reuse Git snapshot index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.2.3] - 2026-08-07
+
+### Changed
+
+- Reuse and safely normalize the private Git snapshot index between turn boundaries, avoiding repeated content hashing for unchanged tracked files while preserving fresh-index ignore and type semantics.
+
 ## [1.2.2] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.2.2
+omp plugin install @baylarsadigov/omp-undo-redo@1.2.3
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -61,7 +61,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.2.2
+pi install npm:@baylarsadigov/omp-undo-redo@1.2.3
 ```
 
 To update installed Pi packages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -10,6 +10,7 @@ import type {
   GitRunner,
   OwnershipMode,
   PendingGitCheckpoint,
+  SnapshotIndexLease,
   SessionReader,
 } from "./types.js";
 
@@ -108,55 +109,159 @@ export async function resolveRepository(git: GitRunner): Promise<RepositoryResol
   };
 }
 
-type SnapshotResult = { hash: string } | { reason: "invalid_head" | "snapshot_failed" };
+type SnapshotResult =
+  | { hash: string; snapshotIndexLease?: SnapshotIndexLease }
+  | { reason: "invalid_head" | "snapshot_failed" };
+
+type SeedSnapshotIndexResult =
+  { status: "seeded"; headTree: string } | { status: "empty" | "invalid_head" | "failed" };
 
 async function seedSnapshotIndex(
   git: GitRunner,
   env: Record<string, string>,
-): Promise<"seeded" | "empty" | "invalid_head" | "failed"> {
+): Promise<SeedSnapshotIndexResult> {
   const headTree = await invoke(git, ["rev-parse", "--verify", "HEAD^{tree}"]);
-  if (headTree.code === 0 && headTree.stdout.trim()) {
-    const seeded = await invoke(git, ["read-tree", headTree.stdout.trim()], { env });
-    return seeded.code === 0 ? "seeded" : "failed";
+  const hash = headTree.stdout.trim();
+  if (headTree.code === 0 && hash) {
+    const seeded = await invoke(git, ["read-tree", hash], { env });
+    return seeded.code === 0 ? { status: "seeded", headTree: hash } : { status: "failed" };
   }
-  if (headTree.error === "unavailable") return "failed";
+  if (headTree.error === "unavailable") return { status: "failed" };
 
   const symbolicHead = await invoke(git, ["symbolic-ref", "-q", "HEAD"]);
-  if (symbolicHead.code !== 0 || !symbolicHead.stdout.trim()) return "invalid_head";
+  if (symbolicHead.code !== 0 || !symbolicHead.stdout.trim()) return { status: "invalid_head" };
   const branchRef = symbolicHead.stdout.trim();
   const branch = await invoke(git, ["show-ref", "--verify", "--quiet", branchRef]);
-  if (branch.code === 0) return "invalid_head";
-  if (branch.error === "unavailable") return "failed";
+  if (branch.code === 0) return { status: "invalid_head" };
+  if (branch.error === "unavailable") return { status: "failed" };
 
   const empty = await invoke(git, ["read-tree", "--empty"], { env });
-  return empty.code === 0 ? "empty" : "failed";
+  return empty.code === 0 ? { status: "empty" } : { status: "failed" };
 }
 
-async function createSnapshotCommit(git: GitRunner, message: string): Promise<SnapshotResult> {
+async function createCommitForTree(
+  git: GitRunner,
+  treeHash: string,
+  message: string,
+): Promise<SnapshotResult> {
+  const commit = await invoke(git, [...GIT_AUTHOR, "commit-tree", treeHash, "-m", message]);
+  if (commit.code !== 0) return { reason: "snapshot_failed" };
+  const commitHash = commit.stdout.trim();
+  return commitHash ? { hash: commitHash } : { reason: "snapshot_failed" };
+}
+
+async function releaseSnapshotIndexLease(lease: SnapshotIndexLease | undefined): Promise<boolean> {
+  if (!lease) return true;
+  try {
+    await rm(lease.directory, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createSnapshotCommit(
+  git: GitRunner,
+  message: string,
+  retainIndex = false,
+): Promise<SnapshotResult> {
   let tempDirectory: string | null = null;
   try {
     tempDirectory = await mkdtemp(join(tmpdir(), "omp-undo-redo-index-"));
     const indexPath = join(tempDirectory, "index");
     const env = { GIT_INDEX_FILE: indexPath };
     const seeded = await seedSnapshotIndex(git, env);
-    if (seeded === "invalid_head") return { reason: "invalid_head" };
-    if (seeded === "failed") return { reason: "snapshot_failed" };
+    if (seeded.status === "invalid_head") return { reason: "invalid_head" };
+    if (seeded.status === "failed") return { reason: "snapshot_failed" };
     const added = await invoke(git, ["add", "-A", "--", WORKTREE_PATHSPEC], { env });
     if (added.code !== 0) return { reason: "snapshot_failed" };
     const tree = await invoke(git, ["write-tree"], { env });
     if (tree.code !== 0) return { reason: "snapshot_failed" };
     const treeHash = tree.stdout.trim();
     if (!treeHash) return { reason: "snapshot_failed" };
-    const commit = await invoke(git, [...GIT_AUTHOR, "commit-tree", treeHash, "-m", message]);
-    if (commit.code !== 0) return { reason: "snapshot_failed" };
-    const commitHash = commit.stdout.trim();
-    return commitHash ? { hash: commitHash } : { reason: "snapshot_failed" };
+    const commit = await createCommitForTree(git, treeHash, message);
+    if (!("hash" in commit)) return commit;
+    if (retainIndex && seeded.status === "seeded") {
+      const snapshotIndexLease = {
+        directory: tempDirectory,
+        indexPath,
+        headTree: seeded.headTree,
+      };
+      tempDirectory = null;
+      return { hash: commit.hash, snapshotIndexLease };
+    }
+    return commit;
   } catch {
     return { reason: "snapshot_failed" };
   } finally {
     if (tempDirectory !== null) {
       await rm(tempDirectory, { recursive: true, force: true }).catch(() => undefined);
     }
+  }
+}
+
+async function createSnapshotCommitFromLease(
+  git: GitRunner,
+  lease: SnapshotIndexLease,
+  message: string,
+): Promise<SnapshotResult> {
+  const currentHead = await invoke(git, ["rev-parse", "--verify", "HEAD^{tree}"]);
+  if (currentHead.code !== 0 || currentHead.stdout.trim() !== lease.headTree) {
+    return { reason: "snapshot_failed" };
+  }
+
+  const normalizationPath = join(lease.directory, `normalize-${randomUUID()}.nul`);
+  const env = { GIT_INDEX_FILE: lease.indexPath };
+  try {
+    const differences = await invoke(
+      git,
+      [
+        "diff-index",
+        "--cached",
+        "--no-renames",
+        "--diff-filter=ADT",
+        "--name-only",
+        "-z",
+        `--output=${normalizationPath}`,
+        lease.headTree,
+        "--",
+      ],
+      { env },
+    );
+    if (differences.code !== 0) return { reason: "snapshot_failed" };
+
+    const normalization = await stat(normalizationPath);
+    if (normalization.size > 0) {
+      const reset = await invoke(
+        git,
+        [
+          "--literal-pathspecs",
+          "reset",
+          "-q",
+          lease.headTree,
+          `--pathspec-from-file=${normalizationPath}`,
+          "--pathspec-file-nul",
+        ],
+        { env },
+      );
+      if (reset.code !== 0) return { reason: "snapshot_failed" };
+    }
+
+    const added = await invoke(git, ["add", "-A", "--", WORKTREE_PATHSPEC], { env });
+    if (added.code !== 0) return { reason: "snapshot_failed" };
+    const tree = await invoke(git, ["write-tree"], { env });
+    const treeHash = tree.stdout.trim();
+    if (tree.code !== 0 || !treeHash) return { reason: "snapshot_failed" };
+
+    const verifiedHead = await invoke(git, ["rev-parse", "--verify", "HEAD^{tree}"]);
+    if (verifiedHead.code !== 0 || verifiedHead.stdout.trim() !== lease.headTree) {
+      return { reason: "snapshot_failed" };
+    }
+    return createCommitForTree(git, treeHash, message);
+  } catch {
+    return { reason: "snapshot_failed" };
+  } finally {
+    await rm(normalizationPath, { force: true }).catch(() => undefined);
   }
 }
 
@@ -282,13 +387,20 @@ export async function releaseCheckpoint(
 
 export async function releasePendingCheckpoint(
   git: GitRunner,
-  pending: Pick<PendingGitCheckpoint, "repository" | "beforeHash" | "beforeRef">,
+  pending: Pick<
+    PendingGitCheckpoint,
+    "repository" | "beforeHash" | "beforeRef" | "snapshotIndexLease"
+  >,
 ): Promise<boolean> {
-  return releaseRefBatch(
-    git,
-    [{ ref: pending.beforeRef, expectedHash: pending.beforeHash }],
-    pending.repository,
-  );
+  const [releasedRef, releasedLease] = await Promise.all([
+    releaseRefBatch(
+      git,
+      [{ ref: pending.beforeRef, expectedHash: pending.beforeHash }],
+      pending.repository,
+    ),
+    releaseSnapshotIndexLease(pending.snapshotIndexLease),
+  ]);
+  return releasedRef && releasedLease;
 }
 
 export type PrepareBeforeTurnResult =
@@ -311,7 +423,7 @@ export async function prepareBeforeTurn(
     ? await ownerRegistry.ensureInitialized(resolved.repository, git)
     : "legacy";
   const checkpointId = randomUUID();
-  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn");
+  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn", true);
   if (!("hash" in snapshot)) {
     return {
       status: "session_only",
@@ -328,6 +440,7 @@ export async function prepareBeforeTurn(
       snapshot.hash,
     ]))
   ) {
+    await releaseSnapshotIndexLease(snapshot.snapshotIndexLease);
     return {
       status: "session_only",
       reason: "before_ref_failed",
@@ -341,6 +454,7 @@ export async function prepareBeforeTurn(
       beforeHash: snapshot.hash,
       beforeRef,
       checkpointId,
+      ...(snapshot.snapshotIndexLease ? { snapshotIndexLease: snapshot.snapshotIndexLease } : {}),
       parentLeafId: null,
     },
   };
@@ -348,11 +462,30 @@ export async function prepareBeforeTurn(
 
 export async function finishAfterTurn(
   git: GitRunner,
-  before: Pick<PendingGitCheckpoint, "repository" | "beforeHash" | "beforeRef" | "checkpointId">,
+  before: Pick<
+    PendingGitCheckpoint,
+    "repository" | "beforeHash" | "beforeRef" | "checkpointId" | "snapshotIndexLease"
+  >,
   parentLeafId: string | null,
   leafId: string | null,
 ): Promise<FinishAfterTurnResult> {
-  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
+  let snapshot: SnapshotResult;
+  if (before.snapshotIndexLease) {
+    try {
+      snapshot = await createSnapshotCommitFromLease(
+        git,
+        before.snapshotIndexLease,
+        "omp-undo-redo: after turn",
+      );
+    } finally {
+      await releaseSnapshotIndexLease(before.snapshotIndexLease);
+    }
+    if (!("hash" in snapshot)) {
+      snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
+    }
+  } else {
+    snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
+  }
   if (!("hash" in snapshot)) {
     await releasePendingCheckpoint(git, before);
     return {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -93,6 +93,12 @@ export interface GitRepository {
   commonDir: string;
 }
 
+export interface SnapshotIndexLease {
+  directory: string;
+  indexPath: string;
+  headTree: string;
+}
+
 export interface GitCheckpoint {
   kind: "git";
   repository: GitRepository;
@@ -135,6 +141,7 @@ export interface PendingGitCheckpoint {
   beforeHash: string;
   beforeRef: string;
   checkpointId: string;
+  snapshotIndexLease?: SnapshotIndexLease;
   parentLeafId: string | null;
 }
 

--- a/test/checkpoints-temp-failures.test.ts
+++ b/test/checkpoints-temp-failures.test.ts
@@ -270,6 +270,8 @@ describe("temp-directory failure resilience", () => {
 
       mockState.failMkdtempPrefix = "omp-undo-redo-index-";
       await writeFile(join(cwd, "tracked.txt"), "changed\n");
+      await rawGit(cwd, ["add", "tracked.txt"]);
+      await rawGit(cwd, ["commit", "-qm", "move HEAD during turn"]);
       ctx.leaf = "turn-1";
 
       await expect(pi.emit("agent_end", ctx)).resolves.toBeUndefined();

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -13,7 +13,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { SessionNavigation } from "../src/core/session-navigation.js";
@@ -25,6 +25,7 @@ import {
   releaseCheckpoint,
   previousCheckpoint,
   releaseRefs,
+  releasePendingCheckpoint,
 } from "../src/core/checkpoints.js";
 import type {
   GitCheckpoint,
@@ -398,6 +399,155 @@ describe("history-safe Git checkpoints", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("reuses and normalizes the alternate index without changing fresh snapshot semantics", async () => {
+    const { cwd, git: baseGit } = await makeRepo();
+    try {
+      await initializeBranch(baseGit, cwd);
+      await writeFile(join(cwd, "headonly.txt"), "tracked before deletion\n");
+      await baseGit(["add", "headonly.txt"]);
+      await baseGit(["commit", "-qm", "tracked deletion fixture"]);
+      await rm(join(cwd, "headonly.txt"));
+      await writeFile(join(cwd, "candidate.txt"), "untracked before turn\n");
+
+      const commands: string[][] = [];
+      const git = Object.assign(
+        async (args: string[], options?: Parameters<GitRunner>[1]) => {
+          commands.push(args);
+          return baseGit(args, options);
+        },
+        { cwd },
+      ) satisfies GitRunner;
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "normalized-index"));
+      const leaseDirectory = before.snapshotIndexLease?.directory;
+      expect(leaseDirectory).toBeDefined();
+      if (!leaseDirectory) return;
+      await expect(stat(leaseDirectory)).resolves.toBeDefined();
+
+      await writeFile(join(cwd, ".gitignore"), "candidate.txt\nheadonly.txt\n");
+      await writeFile(join(cwd, "headonly.txt"), "tracked after recreation\n");
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
+
+      expect(commands.some((args) => args[0] === "diff-index")).toBe(true);
+      await expect(stat(leaseDirectory)).rejects.toThrow();
+      const fresh = pendingCheckpoint(await prepareBeforeTurn(baseGit, "fresh-ground-truth"));
+      expect(await text(baseGit, ["rev-parse", `${after.afterHash}^{tree}`])).toBe(
+        await text(baseGit, ["rev-parse", `${fresh.beforeHash}^{tree}`]),
+      );
+      expect(await text(baseGit, ["ls-tree", "-r", "--name-only", after.afterHash])).toContain(
+        "headonly.txt",
+      );
+      expect(await text(baseGit, ["ls-tree", "-r", "--name-only", after.afterHash])).not.toContain(
+        "candidate.txt",
+      );
+
+      const freshLeaseDirectory = fresh.snapshotIndexLease?.directory;
+      await releasePendingCheckpoint(baseGit, fresh);
+      if (freshLeaseDirectory) await expect(stat(freshLeaseDirectory)).rejects.toThrow();
+      await releaseCheckpoint(baseGit, after);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips index reset when retained membership already matches HEAD", async () => {
+    const { cwd, git: baseGit } = await makeRepo();
+    try {
+      await initializeBranch(baseGit, cwd);
+      const commands: string[][] = [];
+      const git = Object.assign(
+        async (args: string[], options?: Parameters<GitRunner>[1]) => {
+          commands.push(args);
+          return baseGit(args, options);
+        },
+        { cwd },
+      ) satisfies GitRunner;
+
+      const before = pendingCheckpoint(await prepareBeforeTurn(git, "empty-normalization"));
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
+
+      expect(commands.some((args) => args[0] === "diff-index")).toBe(true);
+      expect(commands.some((args) => args.includes("reset"))).toBe(false);
+      await releaseCheckpoint(baseGit, after);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "matches fresh snapshots across regular-file and symlink transitions",
+    async () => {
+      const { cwd, git } = await makeRepo();
+      try {
+        await initializeBranch(git, cwd);
+        await writeFile(join(cwd, "target.txt"), "target\n");
+        await writeFile(join(cwd, "node"), "regular\n");
+        await git(["add", "."]);
+        await git(["commit", "-qm", "type transition fixture"]);
+
+        const regularBefore = pendingCheckpoint(await prepareBeforeTurn(git, "regular-before"));
+        await rm(join(cwd, "node"));
+        await symlink("target.txt", join(cwd, "node"));
+        const symlinkAfter = completedCheckpoint(
+          await finishAfterTurn(git, regularBefore, null, null),
+        );
+        const symlinkFresh = pendingCheckpoint(
+          await prepareBeforeTurn(git, "symlink-fresh-ground-truth"),
+        );
+        expect(await text(git, ["rev-parse", `${symlinkAfter.afterHash}^{tree}`])).toBe(
+          await text(git, ["rev-parse", `${symlinkFresh.beforeHash}^{tree}`]),
+        );
+
+        await rm(join(cwd, "node"));
+        await writeFile(join(cwd, "node"), "regular again\n");
+        const regularAfter = completedCheckpoint(
+          await finishAfterTurn(git, symlinkFresh, null, null),
+        );
+        const regularFresh = pendingCheckpoint(
+          await prepareBeforeTurn(git, "regular-fresh-ground-truth"),
+        );
+        expect(await text(git, ["rev-parse", `${regularAfter.afterHash}^{tree}`])).toBe(
+          await text(git, ["rev-parse", `${regularFresh.beforeHash}^{tree}`]),
+        );
+
+        await releasePendingCheckpoint(git, regularFresh);
+        await releaseCheckpoint(git, symlinkAfter);
+        await releaseCheckpoint(git, regularAfter);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves literal and non-UTF-8 paths while normalizing the retained index",
+    async () => {
+      const { cwd, git } = await makeRepo();
+      try {
+        await initializeBranch(git, cwd);
+        await writeFile(join(cwd, ":(top)-literal\tline\n.txt"), "literal path\n");
+        const nonUtf8Path = Buffer.concat([
+          Buffer.from(cwd),
+          Buffer.from(sep),
+          Buffer.from([0x6e, 0x6f, 0x6e, 0x2d, 0x75, 0x74, 0x66, 0x38, 0x2d, 0x80]),
+        ]);
+        await writeFile(nonUtf8Path, "raw path\n");
+
+        const before = pendingCheckpoint(await prepareBeforeTurn(git, "raw-paths"));
+        const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
+        const fresh = pendingCheckpoint(await prepareBeforeTurn(git, "raw-paths-fresh"));
+
+        expect(await text(git, ["rev-parse", `${after.afterHash}^{tree}`])).toBe(
+          await text(git, ["rev-parse", `${fresh.beforeHash}^{tree}`]),
+        );
+        await releasePendingCheckpoint(git, fresh);
+        await releaseCheckpoint(git, after);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("preserves pre-existing changes outside a subdirectory session across undo and redo", async () => {
     const { cwd, git } = await makeRepo();
     const nested = join(cwd, "nested");
@@ -514,6 +664,39 @@ describe("history-safe Git checkpoints", () => {
       expect(await applyCheckpoint(git, after.beforeHash, after.afterHash)).toBe("applied");
       expect(await text(git, ["symbolic-ref", "--short", "HEAD"])).toBe("A");
       expect(await branchRefs(git)).toBe(refsAfterSwitch);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a fresh index when the HEAD tree changes during the turn", async () => {
+    const { cwd, git: baseGit } = await makeRepo();
+    try {
+      await initializeBranch(baseGit, cwd);
+      const before = pendingCheckpoint(await prepareBeforeTurn(baseGit, "head-tree-change"));
+      await writeFile(join(cwd, "committed.txt"), "committed during turn\n");
+      await baseGit(["add", "committed.txt"]);
+      await baseGit(["commit", "-qm", "move HEAD tree"]);
+      await writeFile(join(cwd, "tracked.txt"), "uncommitted after HEAD move\n");
+
+      const commands: string[][] = [];
+      const git = Object.assign(
+        async (args: string[], options?: Parameters<GitRunner>[1]) => {
+          commands.push(args);
+          return baseGit(args, options);
+        },
+        { cwd },
+      ) satisfies GitRunner;
+      const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
+
+      expect(commands.some((args) => args[0] === "diff-index")).toBe(false);
+      expect(commands.some((args) => args[0] === "read-tree")).toBe(true);
+      const fresh = pendingCheckpoint(await prepareBeforeTurn(baseGit, "head-change-fresh"));
+      expect(await text(baseGit, ["rev-parse", `${after.afterHash}^{tree}`])).toBe(
+        await text(baseGit, ["rev-parse", `${fresh.beforeHash}^{tree}`]),
+      );
+      await releasePendingCheckpoint(baseGit, fresh);
+      await releaseCheckpoint(baseGit, after);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -779,6 +962,7 @@ describe("history-safe Git checkpoints", () => {
       const prepared = await prepareBeforeTurn(git, "unborn");
       expect(prepared.status).toBe("git");
       if (prepared.status !== "git") return;
+      expect(prepared.checkpoint.snapshotIndexLease).toBeUndefined();
 
       await rm(join(cwd, "before.txt"));
       await writeFile(join(cwd, "after.txt"), "after\n");


### PR DESCRIPTION
## Summary
- Reuse and normalize private Git snapshot indexes between turn boundaries.
- Fall back safely when HEAD changes or lease operations fail.
- Update release metadata for v1.2.3.

## Verification
- npm run verify