### PR TITLE
perf: cache unchanged workspace files in BlobStore v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.2.4] - 2026-08-10
+
+### Performance
+
+- Cache unchanged non-Git workspace files in `BlobStore` using file fingerprints (size, mtime, ctime, birthtime, dev) and a racily-clean guard to avoid unnecessary disk re-reads.
+
 ## [1.2.3] - 2026-08-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ omp plugin install @baylarsadigov/omp-undo-redo
 To pin an exact release:
 
 ```sh
-omp plugin install @baylarsadigov/omp-undo-redo@1.2.3
+omp plugin install @baylarsadigov/omp-undo-redo@1.2.4
 ```
 
 OMP discovers the compiled entry through the package manifest:
@@ -61,7 +61,7 @@ pi install npm:@baylarsadigov/omp-undo-redo
 To pin a release:
 
 ```sh
-pi install npm:@baylarsadigov/omp-undo-redo@1.2.3
+pi install npm:@baylarsadigov/omp-undo-redo@1.2.4
 ```
 
 To update installed Pi packages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
+import type { Stats } from "node:fs";
 import {
   mkdir,
   lstat,
@@ -27,6 +28,32 @@ export interface TreeManifest {
   skippedPaths: string[];
 }
 
+interface FileFingerprint {
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  birthtimeMs: number;
+  dev: number;
+  ino: number;
+  mode: number;
+}
+
+interface CachedWorkspaceFile {
+  fingerprint: FileFingerprint;
+  entry: TreeEntry;
+}
+
+interface WorkspaceCache {
+  treeId: string;
+  files: Map<string, CachedWorkspaceFile>;
+  /** Wall-clock epoch (ms) when this cache was populated.  The racily-clean
+   *  guard compares each file's cached mtime against this value so that only
+   *  files whose mtime falls within RACILY_CLEAN_MS of the *prior* capture
+   *  are forced to re-read — closing the FAT/SMB coarse-tick window where a
+   *  rewrite and the observation land on the same tick. */
+  captureTime: number;
+}
+
 export type SnapshotPhase = "before" | "after";
 export type BlobApplyResult =
   { status: "applied"; partial: boolean } | { status: "conflict" } | { status: "failed" };
@@ -46,6 +73,11 @@ export const DEFAULT_BLOB_IGNORES = [
   "target",
 ] as const;
 
+const MAX_CACHED_WORKSPACES = 16;
+const MAX_CACHED_FILES_PER_WORKSPACE = 100_000;
+const MAX_CACHED_FILES = 100_000;
+const RACILY_CLEAN_MS = 4_000;
+
 export function blobStoreRootDirectory(): string {
   if (process.env.OMP_UNDO_REDO_BLOB_DIR) return resolve(process.env.OMP_UNDO_REDO_BLOB_DIR);
   if (process.env.OMP_UNDO_REDO_RUNTIME_DIR) {
@@ -61,6 +93,30 @@ function basenameIsRuntime(value: string): boolean {
 
 function sha256(value: Buffer | string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function fileFingerprint(metadata: Stats): FileFingerprint {
+  return {
+    size: metadata.size,
+    mtimeMs: metadata.mtimeMs,
+    ctimeMs: metadata.ctimeMs,
+    birthtimeMs: metadata.birthtimeMs,
+    dev: metadata.dev,
+    ino: metadata.ino,
+    mode: metadata.mode & 0o777,
+  };
+}
+
+function sameFingerprint(left: FileFingerprint, right: FileFingerprint): boolean {
+  return (
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs &&
+    left.birthtimeMs === right.birthtimeMs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode
+  );
 }
 
 function canonicalManifest(entries: readonly TreeEntry[], skippedPaths: readonly string[]): string {
@@ -95,18 +151,26 @@ export class BlobStore {
   private readonly maxFileBytes: number;
   private readonly ignore: ReadonlySet<string>;
   private readonly clock: () => Date;
+  private readonly readWorkspaceFile: (path: string) => Promise<Buffer>;
   private readonly locks = new Map<string, Promise<void>>();
   private readonly ownerId = randomUUID();
   private leasePublished = false;
+  private readonly workspaceCaches = new Map<string, WorkspaceCache>();
 
   constructor(
     readonly rootDirectory: string,
-    options: { maxFileBytes?: number; ignore?: readonly string[]; clock?: () => Date } = {},
+    options: {
+      maxFileBytes?: number;
+      ignore?: readonly string[];
+      clock?: () => Date;
+      readWorkspaceFile?: (path: string) => Promise<Buffer>;
+    } = {},
   ) {
     this.rootDirectory = resolve(rootDirectory);
     this.maxFileBytes = options.maxFileBytes ?? 16 * 1024 * 1024;
     this.ignore = new Set(options.ignore ?? DEFAULT_BLOB_IGNORES);
     this.clock = options.clock ?? (() => new Date());
+    this.readWorkspaceFile = options.readWorkspaceFile ?? readFile;
   }
 
   private blobPath(hash: string): string {
@@ -248,12 +312,42 @@ export class BlobStore {
     return { hash: hash.digest("hex") };
   }
 
-  private async walkWorkspace(workspaceRoot: string): Promise<{
+  private cacheWorkspace(
+    workspaceRoot: string,
+    treeId: string,
+    files: Map<string, CachedWorkspaceFile>,
+    captureTime: number,
+  ): void {
+    this.workspaceCaches.delete(workspaceRoot);
+    if (files.size > MAX_CACHED_FILES_PER_WORKSPACE) return;
+
+    this.workspaceCaches.set(workspaceRoot, { treeId, files, captureTime });
+    let cachedFileCount = 0;
+    for (const cache of this.workspaceCaches.values()) cachedFileCount += cache.files.size;
+    while (
+      this.workspaceCaches.size > MAX_CACHED_WORKSPACES ||
+      cachedFileCount > MAX_CACHED_FILES
+    ) {
+      const oldest = this.workspaceCaches.entries().next().value;
+      if (!oldest) return;
+      const [oldestWorkspaceRoot, oldestCache] = oldest;
+      this.workspaceCaches.delete(oldestWorkspaceRoot);
+      cachedFileCount -= oldestCache.files.size;
+    }
+  }
+
+  private async walkWorkspace(
+    workspaceRoot: string,
+    cachedFiles: ReadonlyMap<string, CachedWorkspaceFile> | undefined,
+    guardTime: number,
+  ): Promise<{
     entries: TreeEntry[];
     skippedPaths: string[];
+    files: Map<string, CachedWorkspaceFile>;
   }> {
     const entries: TreeEntry[] = [];
     const skippedPaths: string[] = [];
+    const files = new Map<string, CachedWorkspaceFile>();
     const storageRoot = await realpath(this.rootDirectory).catch(() => resolve(this.rootDirectory));
     const normalized = (value: string) =>
       process.platform === "win32" ? value.toLowerCase() : value;
@@ -282,17 +376,36 @@ export class BlobStore {
             skippedPaths.push(relativePath);
             continue;
           }
-          const content = await readFile(fullPath);
+          const fingerprint = fileFingerprint(metadata);
+          const cached = cachedFiles?.get(relativePath);
+          if (cached && sameFingerprint(cached.fingerprint, fingerprint)) {
+            // Racily-clean guard: a same-size in-place rewrite that lands inside the
+            // filesystem's timestamp resolution window (≤2 s on FAT/SMB) produces an
+            // identical fingerprint.  We compare the file's mtime against the *prior*
+            // capture's wall-clock — the window that matters is whether the file was
+            // touched close to when we last observed it.  Two tick-widths (4 s) closes
+            // the coarse-tick corner on FAT where a rewrite and the prior observation
+            // land on the same tick.
+            const racilyClean = Math.abs(cached.fingerprint.mtimeMs - guardTime) < RACILY_CLEAN_MS;
+            if (!racilyClean) {
+              entries.push(cached.entry);
+              files.set(relativePath, cached);
+              continue;
+            }
+          }
+          const content = await this.readWorkspaceFile(fullPath);
           const hash = sha256(content);
           await this.writeBlob(hash, content);
-          entries.push({ path: relativePath, blobHash: hash, mode: metadata.mode & 0o777 });
+          const entry = { path: relativePath, blobHash: hash, mode: fingerprint.mode };
+          entries.push(entry);
+          files.set(relativePath, { fingerprint, entry });
         } else {
           skippedPaths.push(relativePath);
         }
       }
     };
     await walk(workspaceRoot, "");
-    return { entries, skippedPaths };
+    return { entries, skippedPaths, files };
   }
 
   private async recoverWorkspace(workspaceRoot: string): Promise<boolean> {
@@ -345,6 +458,7 @@ export class BlobStore {
           await this.failJournal(journalPath);
           return false;
         }
+        this.workspaceCaches.delete(workspaceRoot);
         if (!(await this.rollbackSnapshot(workspaceRoot, sourceMap, targetMap, expectedPaths))) {
           await this.failJournal(journalPath);
           return false;
@@ -418,18 +532,30 @@ export class BlobStore {
           return { reason: "blob_capture_failed" } as const;
         }
         await this.publishLease();
-        const walked = await this.walkWorkspace(canonicalRoot);
+        const cache = this.workspaceCaches.get(canonicalRoot);
+        // GC shares this lock and clears these entries, so a present tree has retained its blobs.
+        const cachedFiles =
+          cache && (await exists(this.treePath(cache.treeId))) ? cache.files : undefined;
+        if (cache && !cachedFiles) this.workspaceCaches.delete(canonicalRoot);
+        const captureTime = this.clock().getTime();
+        const guardTime = cache?.captureTime ?? captureTime;
+        const walked = await this.walkWorkspace(canonicalRoot, cachedFiles, guardTime);
         walked.entries.sort((left, right) => left.path.localeCompare(right.path));
         walked.skippedPaths.sort();
         const content = canonicalManifest(walked.entries, walked.skippedPaths);
         const treeId = sha256(content);
-        const manifest: TreeManifest = { treeId, ...walked };
+        const manifest: TreeManifest = {
+          treeId,
+          entries: walked.entries,
+          skippedPaths: walked.skippedPaths,
+        };
         const treePath = this.treePath(treeId);
         if (!(await exists(treePath))) await this.atomicWrite(treePath, JSON.stringify(manifest));
         await this.atomicWrite(
           this.refPath("active", sessionHash, checkpointId, phase),
           JSON.stringify({ treeId, ownerId: this.ownerId }),
         );
+        this.cacheWorkspace(canonicalRoot, treeId, walked.files, captureTime);
         return manifest;
       });
     } catch {
@@ -682,6 +808,7 @@ export class BlobStore {
             }
           }
 
+          this.workspaceCaches.delete(root);
           const journalPath = join(this.rootDirectory, "journals", `${randomUUID()}.json`);
           try {
             await this.atomicWrite(
@@ -1049,6 +1176,7 @@ export class BlobStore {
       } catch {
         // Nothing to collect.
       }
+      this.workspaceCaches.clear();
     });
   }
 

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   realpath,
   rm,
   stat,
@@ -60,6 +61,107 @@ describe("non-Git blob store", () => {
       store.applySnapshot(workspace, session, before.treeId, after.treeId),
     ).resolves.toEqual({ status: "applied", partial: false });
     await expect(readFile(join(workspace, "file.txt"), "utf8")).resolves.toBe("after\n");
+    await store.shutdown();
+  });
+
+  it("does not read unchanged workspace files", async () => {
+    const workspace = await temporaryDirectory("omp-blob-cache-workspace-");
+    const storage = await temporaryDirectory("omp-blob-cache-storage-");
+    let workspaceReads = 0;
+    const store = new BlobStore(storage, {
+      readWorkspaceFile: async (path) => {
+        workspaceReads += 1;
+        return readFile(path);
+      },
+    });
+    const session = sessionHash("cache");
+    const checkpoint = randomUUID();
+    const path = join(workspace, "unchanged.txt");
+    await writeFile(path, "unchanged\n");
+    const oldTime = new Date(Date.now() - 10_000);
+    await utimes(path, oldTime, oldTime);
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in before) throw new Error("snapshot failed");
+    expect(workspaceReads).toBe(1);
+    workspaceReads = 0;
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in after) throw new Error("snapshot failed");
+    expect(after.treeId).toBe(before.treeId);
+    expect(workspaceReads).toBe(0);
+    await store.shutdown();
+  });
+
+  it("re-reads files with racily-clean timestamps to prevent stale cache hits", async () => {
+    const workspace = await temporaryDirectory("omp-blob-racy-workspace-");
+    const storage = await temporaryDirectory("omp-blob-racy-storage-");
+    let workspaceReads = 0;
+    // Clock pinned so captureTime ≈ file mtime → racily-clean window triggers.
+    const frozenTime = new Date();
+    const store = new BlobStore(storage, {
+      clock: () => frozenTime,
+      readWorkspaceFile: async (path) => {
+        workspaceReads += 1;
+        return readFile(path);
+      },
+    });
+    const session = sessionHash("racy");
+    const filePath = join(workspace, "file.txt");
+    await writeFile(filePath, "original\n");
+    // Set mtime to exactly frozenTime so the guard's |mtime - captureTime| ≈ 0.
+    await utimes(filePath, frozenTime, frozenTime);
+
+    const before = await store.captureSnapshot(workspace, session, randomUUID(), "before");
+    if ("reason" in before) throw new Error("snapshot failed");
+    expect(workspaceReads).toBe(1);
+
+    // Second capture: file untouched, fingerprint identical, but mtime is within
+    // RACILY_CLEAN_MS of the prior captureTime → guard forces a re-read.
+    workspaceReads = 0;
+    const after = await store.captureSnapshot(workspace, session, randomUUID(), "after");
+    if ("reason" in after) throw new Error("snapshot failed");
+    // Same content → same tree, but the guard must have re-read the file.
+    expect(after.treeId).toBe(before.treeId);
+    expect(workspaceReads).toBe(1);
+    await store.shutdown();
+  });
+
+  it("evicts least-recently-used workspace cache at hard cap", async () => {
+    const storage = await temporaryDirectory("omp-blob-cache-cap-storage-");
+    const store = new BlobStore(storage);
+    const session = sessionHash("cache-cap");
+    const workspaces: Array<{ root: string; path: string }> = [];
+    for (let index = 0; index <= 16; index += 1) {
+      const root = await temporaryDirectory(`omp-blob-cache-cap-workspace-${index}-`);
+      const path = join(root, "file.txt");
+      workspaces.push({ root, path });
+      await writeFile(path, "cached\n");
+      const snapshot = await store.captureSnapshot(root, session, randomUUID(), "before");
+      if ("reason" in snapshot) throw new Error("snapshot failed");
+    }
+    const first = workspaces[0];
+    const caches = Reflect.get(store, "workspaceCaches") as Map<string, unknown>;
+    expect(caches.size).toBe(16);
+    expect(caches.has(first.root)).toBe(false);
+    await store.shutdown();
+  });
+
+  it("rebuilds cache after garbage collection removes its tree", async () => {
+    const workspace = await temporaryDirectory("omp-blob-gc-cache-workspace-");
+    const storage = await temporaryDirectory("omp-blob-gc-cache-storage-");
+    const store = new BlobStore(storage);
+    const session = sessionHash("gc-cache");
+    const checkpoint = randomUUID();
+    const path = join(workspace, "file.txt");
+    await writeFile(path, "cached\n");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in before) throw new Error("snapshot failed");
+
+    await store.releaseCheckpointRefs(session, [checkpoint]);
+    await store.collectGarbage();
+
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in after) throw new Error("snapshot failed");
+    await expect(store.blobExists(after.entries[0].blobHash)).resolves.toBe(true);
     await store.shutdown();
   });
 
@@ -366,6 +468,7 @@ describe("non-Git blob store", () => {
     await writeFile(join(workspace, "stale.txt"), "stale");
     const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
     if ("reason" in snapshot) throw new Error("snapshot failed");
+    expect(await readdir(join(storage, "leases"))).toHaveLength(1);
     const staleOwner = randomUUID();
     const refPath = join(storage, "refs", "active", session, checkpoint, "before.ref");
     await writeFile(refPath, JSON.stringify({ treeId: snapshot.treeId, ownerId: staleOwner }));


### PR DESCRIPTION
Cache unchanged non-Git workspace files using file fingerprints and racily-clean guard to avoid repeated disk reads. All verify checks pass.