### PR TITLE
fix: add peerDependenciesMeta and optimize blob validation for v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.2.5] - 2026-08-10
+
+### Changed
+
+- Add `peerDependenciesMeta` for `@oh-my-pi/pi-coding-agent` in `package.json` to mark the peer dependency as optional, preventing package managers from installing duplicate OMP package instances in plugin directories.
+
+### Performance
+
+- Optimize non-Git snapshot restoration and history verification by validating blob existence only for changed paths in `BlobStore` and deduplicating shared tree checks per history load in `BlobHistoryStore`.
+
 ## [1.2.4] - 2026-08-10
 
 ### Performance
@@ -270,6 +280,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
+[1.2.5]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.2.5
 [1.0.30]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.30
 [1.0.26]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.26
 [1.0.25]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.25

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [
@@ -58,6 +58,11 @@
   },
   "peerDependencies": {
     "@oh-my-pi/pi-coding-agent": ">=16.5.2"
+  },
+  "peerDependenciesMeta": {
+    "@oh-my-pi/pi-coding-agent": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/src/core/blob-history-store.ts
+++ b/src/core/blob-history-store.ts
@@ -123,6 +123,14 @@ export class BlobHistoryStore {
         return null;
       }
       const checkpoints: TurnCheckpoint[] = [];
+      const usableTrees = new Map<string, boolean>();
+      const treeUsable = async (treeId: string): Promise<boolean> => {
+        const cached = usableTrees.get(treeId);
+        if (cached !== undefined) return cached;
+        const usable = await this.store.treeUsable(treeId);
+        usableTrees.set(treeId, usable);
+        return usable;
+      };
       for (const checkpoint of candidate.checkpoints as TurnCheckpoint[]) {
         if (checkpoint.kind === "session") {
           checkpoints.push(checkpoint);
@@ -152,8 +160,8 @@ export class BlobHistoryStore {
             "after",
             checkpoint.afterTreeId,
           )) &&
-          (await this.store.treeUsable(checkpoint.beforeTreeId)) &&
-          (await this.store.treeUsable(checkpoint.afterTreeId));
+          (await treeUsable(checkpoint.beforeTreeId)) &&
+          (await treeUsable(checkpoint.afterTreeId));
         checkpoints.push(
           valid
             ? checkpoint

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -751,18 +751,24 @@ export class BlobStore {
           if (!source || !target) return { status: "failed" };
           const sourceMap = new Map(source.entries.map((entry) => [entry.path, entry]));
           const targetMap = new Map(target.entries.map((entry) => [entry.path, entry]));
-          for (const entry of target.entries) {
-            if (!(await this.blobExists(entry.blobHash))) return { status: "failed" };
-          }
-          for (const entry of source.entries) {
-            if (!(await this.blobExists(entry.blobHash))) return { status: "failed" };
-          }
           const mutations = this.changedPaths(
             sourceMap,
             targetMap,
             source.skippedPaths,
             target.skippedPaths,
           );
+          // Only changed entries can be read while applying or rolling back. Checking every
+          // manifest entry makes a small undo/redo perform two full-tree stat passes.
+          const requiredBlobHashes = new Set<string>();
+          for (const path of mutations) {
+            const sourceEntry = sourceMap.get(path);
+            const targetEntry = targetMap.get(path);
+            if (sourceEntry) requiredBlobHashes.add(sourceEntry.blobHash);
+            if (targetEntry) requiredBlobHashes.add(targetEntry.blobHash);
+          }
+          for (const blobHash of requiredBlobHashes) {
+            if (!(await this.blobExists(blobHash))) return { status: "failed" };
+          }
 
           for (const path of mutations) {
             if (!this.validPath(path)) return { status: "conflict" };

--- a/test/blob-history-store.test.ts
+++ b/test/blob-history-store.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BlobHistoryStore } from "../src/core/blob-history-store.js";
 import { BlobStore } from "../src/core/blob-store.js";
 import { checkpointNamespace } from "../src/core/checkpoints.js";
@@ -82,6 +82,41 @@ describe("blob history store", () => {
       currentIndex: 0,
     });
     await secondStore.shutdown();
+  });
+
+  it("validates a shared tree only once per load", async () => {
+    const workspace = await temporaryDirectory("omp-blob-shared-tree-workspace-");
+    const storage = await temporaryDirectory("omp-blob-shared-tree-storage-");
+    const sessionId = "blob-shared-tree-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const checkpointId = randomUUID();
+    const store = new BlobStore(storage);
+    await writeFile(join(workspace, "file.txt"), "unchanged");
+    const before = await store.captureSnapshot(workspace, sessionHash, checkpointId, "before");
+    const after = await store.captureSnapshot(workspace, sessionHash, checkpointId, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    expect(after.treeId).toBe(before.treeId);
+    await store.retainCheckpointForResume(sessionHash, checkpointId);
+    const checkpoint: BlobCheckpoint = {
+      kind: "blob",
+      workspaceRoot: await realpath(workspace),
+      sessionHash,
+      checkpointId,
+      beforeTreeId: before.treeId,
+      afterTreeId: after.treeId,
+      parentLeafId: "prompt",
+      leafId: "response",
+    };
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    await history.save({ checkpoints: [checkpoint], currentIndex: 0 });
+    const treeUsable = vi.spyOn(store, "treeUsable");
+
+    await expect(history.load(reader())).resolves.toEqual({
+      checkpoints: [checkpoint],
+      currentIndex: 0,
+    });
+    expect(treeUsable).toHaveBeenCalledTimes(1);
+    await store.shutdown();
   });
 
   it("downgrades a checkpoint when a retained tree is missing", async () => {

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -64,6 +64,33 @@ describe("non-Git blob store", () => {
     await store.shutdown();
   });
 
+  it("validates blobs only for changed paths when applying a snapshot", async () => {
+    const workspace = await temporaryDirectory("omp-blob-delta-workspace-");
+    const storage = await temporaryDirectory("omp-blob-delta-storage-");
+    const store = new BlobStore(storage);
+    const session = sessionHash("delta-validation");
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "changed.txt"), "before\n");
+    await writeFile(join(workspace, "unchanged.txt"), "unchanged\n");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    await writeFile(join(workspace, "changed.txt"), "after\n");
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+
+    const unchanged = before.entries.find((entry) => entry.path === "unchanged.txt");
+    if (!unchanged) throw new Error("unchanged entry missing");
+    await rm(join(storage, "blobs", unchanged.blobHash.slice(0, 2), unchanged.blobHash.slice(2)), {
+      force: true,
+    });
+
+    await expect(
+      store.applySnapshot(workspace, session, after.treeId, before.treeId),
+    ).resolves.toEqual({ status: "applied", partial: false });
+    await expect(readFile(join(workspace, "changed.txt"), "utf8")).resolves.toBe("before\n");
+    await expect(readFile(join(workspace, "unchanged.txt"), "utf8")).resolves.toBe("unchanged\n");
+    await store.shutdown();
+  });
+
   it("does not read unchanged workspace files", async () => {
     const workspace = await temporaryDirectory("omp-blob-cache-workspace-");
     const storage = await temporaryDirectory("omp-blob-cache-storage-");


### PR DESCRIPTION
## Summary
- Declare  as an optional peer dependency in  inside  to prevent package managers from installing duplicate OMP instances in plugin directories.
- Optimize non-Git snapshot restoration and history verification by checking blob existence only for changed paths in  and deduplicating shared tree checks per history load in .
- Update release metadata to  and update .

## Verification
- Ran 
> @baylarsadigov/omp-undo-redo@1.2.5 verify
> npm run format:check && npm run lint && npm run typecheck && npm test && npm run build && npm run smoke:package && npm run pack:check


> @baylarsadigov/omp-undo-redo@1.2.5 format:check
> prettier --check .

Checking formatting...
All matched files use Prettier code style!

> @baylarsadigov/omp-undo-redo@1.2.5 lint
> eslint .


> @baylarsadigov/omp-undo-redo@1.2.5 typecheck
> tsc -p tsconfig.json --noEmit


> @baylarsadigov/omp-undo-redo@1.2.5 test
> vitest run


 RUN  v3.2.7 C:/Users/baylar.sadigov/Desktop/Projects/omp-undo-redo

 ✓ test/git-runner.test.ts (6 tests) 903ms
   ✓ Git runner > preserves ordinary Git failures  464ms
   ✓ Git runner > settles stdin commands after Git closes  412ms
 ✓ test/blob-history-store.test.ts (3 tests) 1329ms
   ✓ blob history store > round-trips retained checkpoints across store instances  814ms
   ✓ blob history store > validates a shared tree only once per load  319ms
 ✓ test/runtime-action-state-store.test.ts (7 tests) 283ms
 ✓ test/blob-checkpoints.test.ts (2 tests) 326ms
   ✓ blob checkpoint lifecycle > prepares, finishes, retains, applies, and releases one checkpoint  320ms
 ✓ test/command-behavior.test.ts (13 tests) 103ms
 ✓ test/blob-store.test.ts (20 tests | 2 skipped) 4248ms
   ✓ non-Git blob store > captures, undoes, and redoes regular file changes  716ms
   ✓ non-Git blob store > evicts least-recently-used workspace cache at hard cap  928ms
   ✓ non-Git blob store > recovers an interrupted delete from its journal  335ms
 ✓ test/checkpoint-owners.test.ts (12 tests) 8537ms
   ✓ checkpoint owner boundaries > preserves a live foreign owner with real Git  1425ms
   ✓ checkpoint owner boundaries > reaps only v2 owner refs and preserves legacy and future versions  2005ms
   ✓ checkpoint owner boundaries > falls back to legacy refs when lease publication fails  1784ms
   ✓ checkpoint owner boundaries > keeps a live owner's checkpoints usable for undo and redo during another scan  3210ms
 ✓ test/checkpoints-temp-failures.test.ts (6 tests) 15907ms
   ✓ temp-directory failure resilience > A. before-snapshot allocation failure preserves session-only undo/redo  2067ms
   ✓ temp-directory failure resilience > B. after-snapshot allocation failure releases the pending ref  3000ms
   ✓ temp-directory failure resilience > C. snapshot cleanup failure cannot override successful capture  3238ms
   ✓ temp-directory failure resilience > D. snapshot cleanup failure does not hide an operation failure  2208ms
   ✓ temp-directory failure resilience > E. patch allocation failure returns 'failed' without mutation  2841ms
   ✓ temp-directory failure resilience > F. patch cleanup failure preserves the primary apply result  2550ms
 ✓ test/lifecycle.test.ts (16 tests) 43353ms
   ✓ session-only lifecycle fallback > restores non-Git files during undo and redo  2570ms
   ✓ session-only lifecycle fallback > restores files for turns in an unborn repository  3989ms
   ✓ session-only lifecycle fallback > retains a session boundary when after-snapshot creation fails  2420ms
   ✓ session-only lifecycle fallback > keeps undo and redo traversable across a file-history gap  6156ms
   ✓ runtime action-state lifecycle > publishes non-Git turn availability and active leaf  750ms
   ✓ runtime action-state lifecycle > publishes Undo and Redo results with selected leaves  809ms
   ✓ runtime action-state lifecycle > publishes fresh failed results without changing navigation revision  807ms
   ✓ runtime action-state lifecycle > clears Redo and publishes new leaf after unrelated navigation  2363ms
   ✓ navigation invalidation lifecycle > clears redo after unrelated session tree navigation  2491ms
   ✓ navigation invalidation lifecycle > clears redo for successful source session switches and branches  4698ms
   ✓ navigation invalidation lifecycle > preserves redo when a switch is cancelled before its post-event  2516ms
   ✓ resumed session history > restores undo and redo checkpoints across runtime restarts  3379ms
   ✓ resumed session history > reconstructs conversation-only undo when no durable file history exists  1037ms
   ✓ extension lifecycle cleanup > retains completed checkpoints, releases pending checkpoints, and preserves unrelated refs  2588ms
   ✓ extension lifecycle cleanup > drains pending checkpoints when shutdown interrupts a turn  1938ms
   ✓ extension lifecycle cleanup > retains resumable history for every in-memory session and repository  4833ms
 ✓ test/checkpoints.test.ts (25 tests | 2 skipped) 56488ms
   ✓ history-safe Git checkpoints > keeps an intervening agent commit and preserves refs, index, undo, and redo  6335ms
   ✓ history-safe Git checkpoints > preserves staged turn state while undoing and redoing the worktree  4100ms
   ✓ history-safe Git checkpoints > navigates a completed turn with no file changes  3123ms
   ✓ history-safe Git checkpoints > navigates a turn that changes only ignored files  3338ms
   ✓ history-safe Git checkpoints > reuses and normalizes the alternate index without changing fresh snapshot semantics  3190ms
   ✓ history-safe Git checkpoints > skips index reset when retained membership already matches HEAD  1916ms
   ✓ history-safe Git checkpoints > preserves pre-existing changes outside a subdirectory session across undo and redo  3429ms
   ✓ history-safe Git checkpoints > creates the same snapshot tree regardless of runner cwd  2347ms
   ✓ history-safe Git checkpoints > keeps symbolic HEAD and both branch tips unchanged across a branch switch  3089ms
   ✓ history-safe Git checkpoints > falls back to a fresh index when the HEAD tree changes during the turn  2993ms
   ✓ history-safe Git checkpoints > does not mutate a mixed real index during capture, restoration, or cleanup  4262ms
   ✓ history-safe Git checkpoints > changes only private refs through the complete checkpoint lifecycle  3090ms
   ✓ history-safe Git checkpoints > restores additions, deletions, rename-as-delete/add, binary data, and Unicode names  2888ms
   ✓ history-safe Git checkpoints > fails safely on a conflicting reverse patch and leaves navigation unchanged  2792ms
   ✓ history-safe Git checkpoints > keeps active checkpoints reachable after reflog expiry and aggressive GC  2970ms
   ✓ history-safe Git checkpoints > isolates a changed private ref without blocking valid cleanup  2145ms
   ✓ history-safe Git checkpoints > supports full checkpoints in an unborn repository  2019ms
   ✓ history-safe Git checkpoints > creates valid empty snapshots in an unborn repository  1584ms
   ✓ history-safe Git checkpoints > classifies a malformed HEAD instead of treating it as unborn  802ms

 Test Files  10 passed (10)
      Tests  106 passed | 4 skipped (110)
   Start at  15:09:23
   Duration  57.59s (transform 1.54s, setup 0ms, collect 3.41s, tests 131.48s, environment 5ms, prepare 3.14s)


> @baylarsadigov/omp-undo-redo@1.2.5 prebuild
> npm run clean


> @baylarsadigov/omp-undo-redo@1.2.5 clean
> node scripts/clean-dist.mjs


> @baylarsadigov/omp-undo-redo@1.2.5 build
> tsc -p tsconfig.json


> @baylarsadigov/omp-undo-redo@1.2.5 postbuild
> node scripts/check-dist.mjs

Build output parity check passed.

> @baylarsadigov/omp-undo-redo@1.2.5 smoke:package
> node scripts/smoke-package.mjs

Package entry smoke test passed successfully.

> @baylarsadigov/omp-undo-redo@1.2.5 pack:check
> npm pack --dry-run


> @baylarsadigov/omp-undo-redo@1.2.5 prepack
> npm run build


> @baylarsadigov/omp-undo-redo@1.2.5 prebuild
> npm run clean


> @baylarsadigov/omp-undo-redo@1.2.5 clean
> node scripts/clean-dist.mjs


> @baylarsadigov/omp-undo-redo@1.2.5 build
> tsc -p tsconfig.json


> @baylarsadigov/omp-undo-redo@1.2.5 postbuild
> node scripts/check-dist.mjs

Build output parity check passed.
baylarsadigov-omp-undo-redo-1.2.5.tgz locally (all format, lint, typecheck, tests, build, package smoke checks passed).