### PR TITLE
feat: add snapshot history retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.3.0] - 2026-08-12
+
+### Added
+
+- Add snapshot history retention: dormant session histories untouched for longer than `OMP_UNDO_REDO_RETENTION_DAYS` (default `2`) are expired automatically at startup, so Git refs, blob objects, and history files no longer grow without bound. Expired sessions resume with a warning and session-only undo/redo.
+- Add a storage cap for the non-Git blob store via `OMP_UNDO_REDO_MAX_STORE_MB` (default `1024`, i.e., 1 GiB): when the store exceeds the cap, the oldest inactive session histories are evicted iteratively until it drops back below.
+- Track history access with `lastAccessedAt` (history schema v2, backward compatible with v1) and write expiration tombstones so expired history is reported distinctly from missing or corrupt history.
+- Verify candidate sessions against a live active-session set during expiration so sessions that start concurrently are never expired by their own startup.
+
+### Changed
+
+- Bump history store schema to v2; readers accept v1 and v2, and re-saving writes v2 with a refreshed `lastAccessedAt`.
+- Delete both resumable and stale active refs during expiration and always run garbage collection after cleanup, keeping the blob store consistent.
+- Default retention and storage cap are each `0`-disablable; setting both to `0` disables automatic cleanup entirely (indefinite retention).
+
+### Documentation
+
+- Document retention and storage-cap configuration, the interaction rules between the two variables, how to set them per platform, and the expiration behavior and user-visible messages.
+
 ## [1.2.5] - 2026-08-10
 
 ### Changed
@@ -280,6 +299,7 @@ All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 - OMP plugin-manifest registration through the `omp.extensions` package field.
 - TypeScript build, type-check, lint, format-check, and test tooling.
 
+[1.3.0]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.3.0
 [1.2.5]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.2.5
 [1.0.30]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.30
 [1.0.26]: https://github.com/Baylar55/omp-undo-redo/releases/tag/v1.0.26

--- a/README.md
+++ b/README.md
@@ -84,9 +84,62 @@ Both commands wait for the current agent turn to become idle; if OMP remains bus
 
 Every completed turn remains navigable, including conversation-only turns and turns that change only ignored files. In Git projects, `/undo` and `/redo` restore worktree snapshots without rewriting the Git index. In non-Git workspaces, the built-in snapshot store restores regular files, binary content, and executable modes. Unsupported symlinks and files above the 16 MiB limit are reported as partial restoration. Skipped paths and their overlapping parent or descendant paths remain untouched during partial restoration. Such a session-only checkpoint is a file-history continuity barrier: older file checkpoints are discarded because applying them across an unknown file delta would be unsafe.
 
-Completed Git or non-Git checkpoints and the undo/redo cursor survive a normal terminal restart. Resuming the same session in the same worktree restores both `/undo` and `/redo` history. If durable file metadata is missing or unusable, the extension reconstructs completed turns from the active session branch and offers session-only undo with an explicit warning. A changed worktree must still pass the normal conflict check; resuming never bypasses file-safety checks.
+Completed Git or non-Git checkpoints and the undo/redo cursor survive a normal terminal restart. Resuming the same session in the same worktree restores both `/undo` and `/redo` history, unless the session's file history was removed by the retention policy (see [Configuration](#configuration)). If durable file metadata is missing or unusable, the extension reconstructs completed turns from the active session branch and offers session-only undo with an explicit warning. A changed worktree must still pass the normal conflict check; resuming never bypasses file-safety checks.
 
 While the extension process is running, it publishes normalized Undo/Redo action state for external clients. State lives in a private process-scoped directory at `~/.omp/omp-undo-redo/runtime/<pid>/`; set `OMP_UNDO_REDO_RUNTIME_DIR` to override the root for tests or deployments. Session filenames use SHA-256 session namespaces, and state includes action availability, selected leaf, navigation revision, and the latest action result. Runtime publication is observational and does not add file restoration to session-only mode.
+
+## Configuration
+
+The extension supports optional environment variables to configure snapshot history retention and storage limits:
+
+- `OMP_UNDO_REDO_RETENTION_DAYS` — Inactivity retention threshold in days (default: `2`). Dormant session history untouched for longer than this limit is deleted on extension startup. The clock counts from the session's last access; resuming or using a session refreshes it. Set to `0` to disable age-based expiration.
+- `OMP_UNDO_REDO_MAX_STORE_MB` — Maximum storage cap for the non-Git blob store in MiB (default: `1024`, i.e., 1 GiB). If store size exceeds this limit, the oldest inactive session histories are evicted iteratively until total size drops below the cap. Set to `0` to disable storage cap enforcement. Applies to the non-Git blob store only.
+
+### Setting the variables
+
+Set these in your Pi/OMP process environment. The extension reads them **once, when it loads**, so set them before starting the agent — changing them while a session is open has no effect. The values are global to the agent process, not per project.
+
+**Linux / macOS (bash, zsh)** — export in the current terminal, or add to `~/.bashrc` / `~/.zshrc` so they persist across sessions:
+
+```sh
+export OMP_UNDO_REDO_RETENTION_DAYS=7
+export OMP_UNDO_REDO_MAX_STORE_MB=2048
+```
+
+**Windows PowerShell** — for the current session:
+
+```powershell
+$env:OMP_UNDO_REDO_RETENTION_DAYS = "7"
+$env:OMP_UNDO_REDO_MAX_STORE_MB = "2048"
+```
+
+**Windows (persistent)** — use `setx`, then open a new terminal:
+
+```powershell
+setx OMP_UNDO_REDO_RETENTION_DAYS 7
+setx OMP_UNDO_REDO_MAX_STORE_MB 2048
+```
+
+To disable either behavior, set its value to `0`; setting both to `0` disables automatic cleanup entirely (indefinite retention).
+
+### Setting interaction rules
+
+| `RETENTION_DAYS` | `MAX_STORE_MB`   | Behavior                                                                                                  |
+| ---------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `2` (default)    | `1024` (default) | Age expiration (2 days) + blob storage cap enforcement (1 GiB)                                            |
+| `0`              | `1024`           | No age expiration; storage cap can still evict oldest inactive sessions if total blob store exceeds 1 GiB |
+| `2`              | `0`              | Age expiration (2 days); no storage cap enforcement                                                       |
+| `0`              | `0`              | No automatic cleanup (indefinite retention)                                                               |
+
+> **Note:** `OMP_UNDO_REDO_RETENTION_DAYS=0` disables age-based expiration but does **not** guarantee indefinite history retention when a storage cap is active (`MAX_STORE_MB > 0`). The cap can still evict the oldest inactive session histories to free up storage space. Active sessions are never evicted by age or storage cap.
+
+### Expiration behavior
+
+Cleanup runs automatically at extension startup; nothing runs during active work, and sessions currently in use are never expired or evicted. Successful cleanup is silent. When a dormant session's file history is expired, resuming that session shows a warning: session navigation still works, but file changes from the expired turns cannot be restored, and `/undo`/`/redo` degrade to session-only navigation.
+
+In Git workspaces, expiration removes the session's history refs under `refs/omp-undo-redo/history/<sessionHash>/` and its history file. The referenced commit objects become unreachable and are reclaimed later by the repository's normal `git gc`; `.git` size does not shrink immediately. No storage cap applies to Git object storage.
+
+In non-Git workspaces, expiration removes the session's refs and history file, then garbage-collects orphaned blobs and tree manifests from `~/.omp/omp-undo-redo/`. When the storage cap is set, the oldest inactive sessions are evicted iteratively until the store is back under the cap.
 
 ## Limitations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/commands/redo.ts
+++ b/src/commands/redo.ts
@@ -27,6 +27,8 @@ function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
       return "the file snapshot could not be created.";
     case "blob_apply_failed":
       return "the file snapshot could not be restored.";
+    case "history_expired":
+      return "undo/redo file history for this session expired due to inactivity.";
     default:
       return "the file checkpoint could not be created.";
   }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -27,6 +27,8 @@ function unavailableMessage(reason: FileCheckpointUnavailableReason): string {
       return "the file snapshot could not be created.";
     case "blob_apply_failed":
       return "the file snapshot could not be restored.";
+    case "history_expired":
+      return "undo/redo file history for this session expired due to inactivity.";
     default:
       return "the file checkpoint could not be created.";
   }

--- a/src/core/blob-history-store.ts
+++ b/src/core/blob-history-store.ts
@@ -7,13 +7,16 @@ import { checkpointNamespace } from "./checkpoints.js";
 import { effectiveLeaf, entryExists, expectedLeaf } from "./session-tree-utils.js";
 import type {
   BlobCheckpoint,
+  ExpirationTombstone,
   FileCheckpointUnavailableReason,
+  HistoryLoadResult,
   NavigationState,
   SessionReader,
   TurnCheckpoint,
 } from "./types.js";
 
-const HISTORY_SCHEMA = 1;
+const HISTORY_SCHEMA_CURRENT = 2;
+const ACCEPTED_SCHEMAS = new Set([1, 2]);
 const MAX_HISTORY_BYTES = 4 * 1024 * 1024;
 const HASH = /^[0-9a-f]{64}$/;
 const REASONS: Record<FileCheckpointUnavailableReason, true> = {
@@ -31,6 +34,7 @@ const REASONS: Record<FileCheckpointUnavailableReason, true> = {
   before_blob_failed: true,
   after_blob_failed: true,
   blob_apply_failed: true,
+  history_expired: true,
 };
 
 type StoredHistory = {
@@ -39,6 +43,7 @@ type StoredHistory = {
   workspaceRoot: string;
   checkpoints: TurnCheckpoint[];
   currentIndex: number;
+  lastAccessedAt?: string;
 };
 
 function isNullableString(value: unknown): value is string | null {
@@ -77,6 +82,44 @@ export function blobHistoryPath(sessionId: string, root = blobStoreRootDirectory
   return join(root, "history", `${checkpointNamespace(sessionId)}.json`);
 }
 
+export function blobTombstonePath(
+  sessionIdOrHash: string,
+  root = blobStoreRootDirectory(),
+): string {
+  const sessionHash = HASH.test(sessionIdOrHash)
+    ? sessionIdOrHash
+    : checkpointNamespace(sessionIdOrHash);
+  return join(root, "history", `${sessionHash}.expired.json`);
+}
+
+async function readTombstone(
+  tombstoneFilePath: string,
+  sessionHash: string,
+): Promise<ExpirationTombstone | null> {
+  try {
+    const content = await readFile(tombstoneFilePath, "utf8");
+    const parsed = JSON.parse(content) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const candidate = parsed as Record<string, unknown>;
+    if (
+      candidate.expired === true &&
+      candidate.sessionHash === sessionHash &&
+      typeof candidate.expiredAt === "string" &&
+      (candidate.reason === "age" || candidate.reason === "storage_cap")
+    ) {
+      return {
+        expired: true,
+        sessionHash,
+        expiredAt: candidate.expiredAt,
+        reason: candidate.reason,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export class BlobHistoryStore {
   readonly sessionHash: string;
   private readonly path: string;
@@ -100,27 +143,34 @@ export class BlobHistoryStore {
     }
   }
 
-  async load(reader: SessionReader): Promise<NavigationState | null> {
+  async load(reader: SessionReader): Promise<HistoryLoadResult> {
+    const tombstoneFile = blobTombstonePath(this.sessionId, this.store.rootDirectory);
+    const tombstone = await readTombstone(tombstoneFile, this.sessionHash);
+    if (tombstone) {
+      return { status: "expired", reason: tombstone.reason };
+    }
+
     const workspace = await this.canonicalWorkspace();
-    if (!workspace) return null;
+    if (!workspace) return { status: "unavailable" };
     try {
       const metadata = await stat(this.path);
-      if (!metadata.isFile() || metadata.size > MAX_HISTORY_BYTES) return null;
+      if (!metadata.isFile() || metadata.size > MAX_HISTORY_BYTES) return { status: "unavailable" };
       const value = JSON.parse(await readFile(this.path, "utf8")) as unknown;
-      if (!value || typeof value !== "object") return null;
+      if (!value || typeof value !== "object") return { status: "unavailable" };
       const candidate = value as Record<string, unknown>;
       if (
-        candidate.schemaVersion !== HISTORY_SCHEMA ||
+        typeof candidate.schemaVersion !== "number" ||
+        !ACCEPTED_SCHEMAS.has(candidate.schemaVersion) ||
         candidate.sessionHash !== this.sessionHash ||
         candidate.workspaceRoot !== workspace ||
         !Array.isArray(candidate.checkpoints) ||
         !Number.isInteger(candidate.currentIndex)
       )
-        return null;
+        return { status: "unavailable" };
       if (
         !candidate.checkpoints.every((checkpoint) => isSession(checkpoint) || isBlob(checkpoint))
       ) {
-        return null;
+        return { status: "unavailable" };
       }
       const checkpoints: TurnCheckpoint[] = [];
       const usableTrees = new Map<string, boolean>();
@@ -174,7 +224,7 @@ export class BlobHistoryStore {
         );
       }
       const currentIndex = candidate.currentIndex as number;
-      if (currentIndex < -1 || currentIndex >= checkpoints.length) return null;
+      if (currentIndex < -1 || currentIndex >= checkpoints.length) return { status: "unavailable" };
       const state = { checkpoints, currentIndex };
       if (
         checkpoints.some(
@@ -184,10 +234,13 @@ export class BlobHistoryStore {
         ) ||
         expectedLeaf(state) !== effectiveLeaf(reader)
       )
-        return null;
-      return state;
+        return { status: "unavailable" };
+
+      await this.save(state).catch(() => undefined);
+
+      return { status: "loaded", state };
     } catch {
-      return null;
+      return { status: "unavailable" };
     }
   }
 
@@ -215,11 +268,12 @@ export class BlobHistoryStore {
       };
     });
     const stored: StoredHistory = {
-      schemaVersion: HISTORY_SCHEMA,
+      schemaVersion: HISTORY_SCHEMA_CURRENT,
       sessionHash: this.sessionHash,
       workspaceRoot: workspace,
       checkpoints,
       currentIndex: state.currentIndex,
+      lastAccessedAt: new Date().toISOString(),
     };
     const temporary = join(directory, `.${this.sessionHash}.${randomUUID()}.tmp`);
     try {

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -119,15 +119,30 @@ function sameFingerprint(left: FileFingerprint, right: FileFingerprint): boolean
   );
 }
 
+function comparePaths(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortCanonical(entries: TreeEntry[], skippedPaths: string[]): void {
+  entries.sort((left, right) => comparePaths(left.path, right.path));
+  skippedPaths.sort(comparePaths);
+}
+
 function canonicalManifest(entries: readonly TreeEntry[], skippedPaths: readonly string[]): string {
-  return JSON.stringify({
-    entries: [...entries].sort((left, right) => left.path.localeCompare(right.path)),
-    skippedPaths: [...skippedPaths].sort(),
-  });
+  // Pure serializer of the exact order given. Producers (captureSnapshot) must pre-sort
+  // via sortCanonical so the SHA-256 treeId is deterministic. loadManifest intentionally
+  // does NOT re-sort: it must reproduce the exact on-disk order that was hashed at write
+  // time (newer snapshots used comparePaths, older ones localeCompare), otherwise the
+  // stored treeId wouldn't match and existing snapshots would be rejected.
+  return JSON.stringify({ entries, skippedPaths });
 }
 
 function depth(value: string): number {
-  return value.split("/").length;
+  let count = 1;
+  for (let index = 0; index < value.length; index++) {
+    if (value.charCodeAt(index) === 47) count++; // "/"
+  }
+  return count;
 }
 
 function isHash(value: unknown): value is string {
@@ -502,7 +517,10 @@ export class BlobStore {
       }
       return false;
     };
-    return [...new Set([...source.keys(), ...target.keys()])]
+    const merged = new Set<string>();
+    for (const key of source.keys()) merged.add(key);
+    for (const key of target.keys()) merged.add(key);
+    return [...merged]
       .filter((path) => !overlapsSkipped(path))
       .filter((path) => {
         const left = source.get(path);
@@ -540,8 +558,9 @@ export class BlobStore {
         const captureTime = this.clock().getTime();
         const guardTime = cache?.captureTime ?? captureTime;
         const walked = await this.walkWorkspace(canonicalRoot, cachedFiles, guardTime);
-        walked.entries.sort((left, right) => left.path.localeCompare(right.path));
-        walked.skippedPaths.sort();
+        // Sort the walked arrays once, explicitly, so the on-disk manifest is sorted
+        // and canonicalManifest stays a pure serializer (no redundant second sort).
+        sortCanonical(walked.entries, walked.skippedPaths);
         const content = canonicalManifest(walked.entries, walked.skippedPaths);
         const treeId = sha256(content);
         const manifest: TreeManifest = {
@@ -1137,53 +1156,57 @@ export class BlobStore {
 
   async collectGarbage(): Promise<void> {
     await this.withStoreLock(async () => {
-      await this.cleanupStaleActiveRefs();
-      const referencedTrees = new Set<string>();
-      const scanRefs = async (directory: string): Promise<void> => {
-        let children;
-        try {
-          children = await readdir(directory, { withFileTypes: true });
-        } catch {
-          return;
-        }
-        for (const child of children) {
-          const path = join(directory, child.name);
-          if (child.isDirectory()) await scanRefs(path);
-          else if (child.name.endsWith(".ref")) {
-            const ref = await this.readRef(path);
-            if (ref) referencedTrees.add(ref.treeId);
-          }
-        }
-      };
-      await scanRefs(join(this.rootDirectory, "refs"));
-      const referencedBlobs = new Set<string>();
-      for (const treeId of referencedTrees) {
-        const manifest = await this.loadManifest(treeId);
-        for (const entry of manifest?.entries ?? []) referencedBlobs.add(entry.blobHash);
-      }
-      try {
-        for (const child of await readdir(join(this.rootDirectory, "trees"))) {
-          if (!child.endsWith(".json")) continue;
-          const treeId = child.slice(0, -5);
-          if (!referencedTrees.has(treeId))
-            await rm(join(this.rootDirectory, "trees", child), { force: true });
-        }
-      } catch {
-        // Nothing to collect.
-      }
-      try {
-        for (const prefix of await readdir(join(this.rootDirectory, "blobs"))) {
-          const directory = join(this.rootDirectory, "blobs", prefix);
-          for (const child of await readdir(directory)) {
-            const hash = `${prefix}${child}`;
-            if (!referencedBlobs.has(hash)) await rm(join(directory, child), { force: true });
-          }
-        }
-      } catch {
-        // Nothing to collect.
-      }
-      this.workspaceCaches.clear();
+      await this.collectGarbageUnlocked();
     });
+  }
+
+  private async collectGarbageUnlocked(): Promise<void> {
+    await this.cleanupStaleActiveRefs();
+    const referencedTrees = new Set<string>();
+    const scanRefs = async (directory: string): Promise<void> => {
+      let children;
+      try {
+        children = await readdir(directory, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const child of children) {
+        const path = join(directory, child.name);
+        if (child.isDirectory()) await scanRefs(path);
+        else if (child.name.endsWith(".ref")) {
+          const ref = await this.readRef(path);
+          if (ref) referencedTrees.add(ref.treeId);
+        }
+      }
+    };
+    await scanRefs(join(this.rootDirectory, "refs"));
+    const referencedBlobs = new Set<string>();
+    for (const treeId of referencedTrees) {
+      const manifest = await this.loadManifest(treeId);
+      for (const entry of manifest?.entries ?? []) referencedBlobs.add(entry.blobHash);
+    }
+    try {
+      for (const child of await readdir(join(this.rootDirectory, "trees"))) {
+        if (!child.endsWith(".json")) continue;
+        const treeId = child.slice(0, -5);
+        if (!referencedTrees.has(treeId))
+          await rm(join(this.rootDirectory, "trees", child), { force: true });
+      }
+    } catch {
+      // Nothing to collect.
+    }
+    try {
+      for (const prefix of await readdir(join(this.rootDirectory, "blobs"))) {
+        const directory = join(this.rootDirectory, "blobs", prefix);
+        for (const child of await readdir(directory)) {
+          const hash = `${prefix}${child}`;
+          if (!referencedBlobs.has(hash)) await rm(join(directory, child), { force: true });
+        }
+      }
+    } catch {
+      // Nothing to collect.
+    }
+    this.workspaceCaches.clear();
   }
 
   async garbageCollect(): Promise<void> {
@@ -1217,6 +1240,183 @@ export class BlobStore {
       () => undefined,
     );
     this.leasePublished = false;
+  }
+
+  async measureStoreBytes(): Promise<number> {
+    let totalBytes = 0;
+    const scanDir = async (directory: string): Promise<void> => {
+      let children;
+      try {
+        children = await readdir(directory, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const child of children) {
+        const fullPath = join(directory, child.name);
+        if (child.isDirectory()) {
+          await scanDir(fullPath);
+        } else if (child.isFile()) {
+          try {
+            const metadata = await stat(fullPath);
+            totalBytes += metadata.size;
+          } catch {
+            // Ignore transient errors
+          }
+        }
+      }
+    };
+    await scanDir(join(this.rootDirectory, "blobs"));
+    await scanDir(join(this.rootDirectory, "trees"));
+    return totalBytes;
+  }
+
+  async releaseSessionRefs(sessionHash: string): Promise<boolean> {
+    if (!isHash(sessionHash)) return false;
+    try {
+      return await this.withStoreLock(async () => {
+        let success = true;
+        for (const namespace of ["history", "active"] as const) {
+          await rm(join(this.rootDirectory, "refs", namespace, sessionHash), {
+            recursive: true,
+            force: true,
+          }).catch(() => {
+            success = false;
+          });
+        }
+        return success;
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  async expireAndCollect(
+    retentionDays: number,
+    maxStoreBytes: number,
+    activeSessionHashes: ReadonlySet<string> | (() => ReadonlySet<string>),
+  ): Promise<void> {
+    await this.withStoreLock(async () => {
+      const historyDir = join(this.rootDirectory, "history");
+      const getActive = () =>
+        typeof activeSessionHashes === "function" ? activeSessionHashes() : activeSessionHashes;
+
+      const getHistoryFiles = async (): Promise<string[]> => {
+        try {
+          const files = await readdir(historyDir);
+          return files.filter(
+            (f) => f.endsWith(".json") && !f.endsWith(".expired.json") && !f.startsWith("."),
+          );
+        } catch {
+          return [];
+        }
+      };
+
+      const removeSessionRefsInternal = async (sessionHash: string): Promise<boolean> => {
+        try {
+          for (const namespace of ["history", "active"] as const) {
+            await rm(join(this.rootDirectory, "refs", namespace, sessionHash), {
+              recursive: true,
+              force: true,
+            });
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      const parseSessionTimestamp = async (
+        file: string,
+      ): Promise<{ sessionHash: string; timestamp: number; filePath: string } | null> => {
+        const sessionHash = file.slice(0, -5);
+        if (!isHash(sessionHash)) return null;
+        if (getActive().has(sessionHash)) return null;
+        const filePath = join(historyDir, file);
+        try {
+          const content = await readFile(filePath, "utf8");
+          const parsed = JSON.parse(content) as unknown;
+          if (!parsed || typeof parsed !== "object") return null;
+          const candidate = parsed as Record<string, unknown>;
+          let timestamp: number;
+          if (typeof candidate.lastAccessedAt === "string") {
+            timestamp = Date.parse(candidate.lastAccessedAt);
+            if (Number.isNaN(timestamp)) return null;
+          } else {
+            const st = await stat(filePath);
+            timestamp = st.mtimeMs;
+          }
+          return { sessionHash, timestamp, filePath };
+        } catch {
+          return null;
+        }
+      };
+
+      // Phase 1: Age-based expiration
+      if (retentionDays > 0) {
+        const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+        const files = await getHistoryFiles();
+        for (const file of files) {
+          const item = await parseSessionTimestamp(file);
+          if (!item) continue;
+          if (item.timestamp <= cutoff) {
+            if (getActive().has(item.sessionHash)) continue;
+            const refsDeleted = await removeSessionRefsInternal(item.sessionHash);
+            if (!refsDeleted) continue;
+
+            const tombstoneFile = join(historyDir, `${item.sessionHash}.expired.json`);
+            const tombstoneData = {
+              expired: true,
+              sessionHash: item.sessionHash,
+              expiredAt: new Date().toISOString(),
+              reason: "age",
+            };
+            await this.atomicWrite(tombstoneFile, JSON.stringify(tombstoneData)).catch(
+              () => undefined,
+            );
+            await rm(item.filePath, { force: true }).catch(() => undefined);
+          }
+        }
+      }
+
+      // Phase 2: Storage cap eviction
+      if (maxStoreBytes > 0) {
+        let currentBytes = await this.measureStoreBytes();
+        if (currentBytes > maxStoreBytes) {
+          const files = await getHistoryFiles();
+          const items: Array<{ sessionHash: string; timestamp: number; filePath: string }> = [];
+          for (const file of files) {
+            const item = await parseSessionTimestamp(file);
+            if (item) items.push(item);
+          }
+          items.sort((a, b) => a.timestamp - b.timestamp);
+
+          for (const item of items) {
+            if (getActive().has(item.sessionHash)) continue;
+            currentBytes = await this.measureStoreBytes();
+            if (currentBytes <= maxStoreBytes) break;
+
+            const refsDeleted = await removeSessionRefsInternal(item.sessionHash);
+            if (!refsDeleted) continue;
+
+            const tombstoneFile = join(historyDir, `${item.sessionHash}.expired.json`);
+            const tombstoneData = {
+              expired: true,
+              sessionHash: item.sessionHash,
+              expiredAt: new Date().toISOString(),
+              reason: "storage_cap",
+            };
+            await this.atomicWrite(tombstoneFile, JSON.stringify(tombstoneData)).catch(
+              () => undefined,
+            );
+            await rm(item.filePath, { force: true }).catch(() => undefined);
+            await this.collectGarbageUnlocked();
+          }
+        }
+      }
+
+      // Always perform garbage collection and stale active-ref cleanup
+      await this.collectGarbageUnlocked();
+    });
   }
 
   async treeExists(treeId: string): Promise<boolean> {

--- a/src/core/history-store.ts
+++ b/src/core/history-store.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { checkpointNamespace } from "./checkpoints.js";
 import type {
+  ExpirationTombstone,
   FileCheckpointUnavailableReason,
   GitCheckpoint,
   GitRepository,
   GitRunner,
+  HistoryLoadResult,
   NavigationState,
   SessionReader,
   TurnCheckpoint,
@@ -24,9 +26,11 @@ export {
   isSessionExitEntry,
 } from "./session-tree-utils.js";
 
-const HISTORY_SCHEMA = 1;
+const HISTORY_SCHEMA_CURRENT = 2;
+const ACCEPTED_SCHEMAS = new Set([1, 2]);
 const MAX_HISTORY_BYTES = 4 * 1024 * 1024;
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/;
+const HASH = /^[0-9a-f]{64}$/;
 const UNAVAILABLE_REASONS: Record<FileCheckpointUnavailableReason, true> = {
   git_unavailable: true,
   not_repository: true,
@@ -42,6 +46,7 @@ const UNAVAILABLE_REASONS: Record<FileCheckpointUnavailableReason, true> = {
   before_blob_failed: true,
   after_blob_failed: true,
   blob_apply_failed: true,
+  history_expired: true,
 };
 
 type StoredHistory = {
@@ -50,14 +55,50 @@ type StoredHistory = {
   repository: GitRepository;
   checkpoints: TurnCheckpoint[];
   currentIndex: number;
+  lastAccessedAt?: string;
 };
 
-function historyDirectory(repository: GitRepository): string {
+export function historyDirectory(repository: GitRepository): string {
   return join(repository.commonDir, "omp-undo-redo", "history");
 }
 
 export function historyPath(repository: GitRepository, sessionId: string): string {
   return join(historyDirectory(repository), `${checkpointNamespace(sessionId)}.json`);
+}
+
+export function tombstonePath(repository: GitRepository, sessionIdOrHash: string): string {
+  const sessionHash = HASH.test(sessionIdOrHash)
+    ? sessionIdOrHash
+    : checkpointNamespace(sessionIdOrHash);
+  return join(historyDirectory(repository), `${sessionHash}.expired.json`);
+}
+
+async function readTombstone(
+  tombstoneFilePath: string,
+  sessionHash: string,
+): Promise<ExpirationTombstone | null> {
+  try {
+    const content = await readFile(tombstoneFilePath, "utf8");
+    const parsed = JSON.parse(content) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const candidate = parsed as Record<string, unknown>;
+    if (
+      candidate.expired === true &&
+      candidate.sessionHash === sessionHash &&
+      typeof candidate.expiredAt === "string" &&
+      (candidate.reason === "age" || candidate.reason === "storage_cap")
+    ) {
+      return {
+        expired: true,
+        sessionHash,
+        expiredAt: candidate.expiredAt,
+        reason: candidate.reason,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function isNullableString(value: unknown): value is string | null {
@@ -124,7 +165,8 @@ function parseHistory(
   const sessionHash = checkpointNamespace(sessionId);
   const refPrefix = `refs/omp-undo-redo/history/${sessionHash}/`;
   if (
-    candidate.schemaVersion !== HISTORY_SCHEMA ||
+    typeof candidate.schemaVersion !== "number" ||
+    !ACCEPTED_SCHEMAS.has(candidate.schemaVersion) ||
     candidate.sessionHash !== sessionHash ||
     !isRepository(candidate.repository) ||
     !sameRepository(candidate.repository, repository) ||
@@ -141,12 +183,15 @@ function parseHistory(
   const checkpoints = candidate.checkpoints as TurnCheckpoint[];
   const currentIndex = candidate.currentIndex as number;
   if (currentIndex < -1 || currentIndex >= checkpoints.length) return null;
+  const lastAccessedAt =
+    typeof candidate.lastAccessedAt === "string" ? candidate.lastAccessedAt : undefined;
   return {
-    schemaVersion: HISTORY_SCHEMA,
+    schemaVersion: candidate.schemaVersion,
     sessionHash,
     repository,
     checkpoints,
     currentIndex,
+    lastAccessedAt,
   };
 }
 
@@ -194,6 +239,93 @@ export function reconstructSessionHistory(reader: SessionReader): NavigationStat
   return { checkpoints, currentIndex: checkpoints.length - 1 };
 }
 
+export async function expireGitSessionHistories(
+  repository: GitRepository,
+  git: GitRunner,
+  retentionDays: number,
+  activeSessionHashes: ReadonlySet<string> | (() => ReadonlySet<string>),
+): Promise<void> {
+  if (retentionDays <= 0) return;
+  const dir = historyDirectory(repository);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  const getActive = () =>
+    typeof activeSessionHashes === "function" ? activeSessionHashes() : activeSessionHashes;
+  for (const file of files) {
+    if (!file.endsWith(".json") || file.endsWith(".expired.json") || file.startsWith(".")) continue;
+    const sessionHash = file.slice(0, -5);
+    if (!HASH.test(sessionHash)) continue;
+    if (getActive().has(sessionHash)) continue;
+
+    const filePath = join(dir, file);
+    let lastAccessedAtMs: number;
+    try {
+      const content = await readFile(filePath, "utf8");
+      const parsed = JSON.parse(content) as unknown;
+      if (!parsed || typeof parsed !== "object") continue;
+      const candidate = parsed as Record<string, unknown>;
+      if (typeof candidate.lastAccessedAt === "string") {
+        lastAccessedAtMs = Date.parse(candidate.lastAccessedAt);
+        if (Number.isNaN(lastAccessedAtMs)) continue;
+      } else {
+        const metadata = await stat(filePath);
+        lastAccessedAtMs = metadata.mtimeMs;
+      }
+    } catch {
+      continue;
+    }
+
+    if (lastAccessedAtMs > cutoff) continue;
+
+    // Re-check active set right before deletion to prevent racing concurrent session startup
+    if (getActive().has(sessionHash)) continue;
+
+    const refPrefix = `refs/omp-undo-redo/history/${sessionHash}/`;
+    const refsMap = await existingRefs(git, refPrefix);
+    if (refsMap === null) continue;
+
+    if (refsMap.size > 0) {
+      const deleteCommands = Array.from(refsMap.entries())
+        .map(([ref, hash]) => `delete ${ref} ${hash}`)
+        .join("\n");
+      try {
+        const updateResult = await git(["update-ref", "--stdin"], {
+          stdin: `${deleteCommands}\n`,
+        });
+        if (updateResult.code !== 0 || updateResult.error) continue;
+      } catch {
+        continue;
+      }
+    }
+
+    // Write tombstone first, then delete history JSON
+    const tombstoneFile = tombstonePath(repository, sessionHash);
+    const tombstoneData: ExpirationTombstone = {
+      expired: true,
+      sessionHash,
+      expiredAt: new Date().toISOString(),
+      reason: "age",
+    };
+    const temporary = join(dir, `.${sessionHash}.${randomUUID()}.tmp`);
+    try {
+      await mkdir(dir, { recursive: true, mode: 0o700 });
+      await writeFile(temporary, JSON.stringify(tombstoneData), { encoding: "utf8", mode: 0o600 });
+      await rename(temporary, tombstoneFile);
+    } catch {
+      // tombstone write failure is non-fatal
+    } finally {
+      await rm(temporary, { force: true }).catch(() => undefined);
+    }
+
+    await rm(filePath, { force: true }).catch(() => undefined);
+  }
+}
+
 export class SessionHistoryStore {
   constructor(
     private readonly sessionId: string,
@@ -201,20 +333,27 @@ export class SessionHistoryStore {
     private readonly git: GitRunner,
   ) {}
 
-  async load(reader: SessionReader): Promise<NavigationState | null> {
+  async load(reader: SessionReader): Promise<HistoryLoadResult> {
+    const sessionHash = checkpointNamespace(this.sessionId);
+    const tombstoneFile = tombstonePath(this.repository, this.sessionId);
+    const tombstone = await readTombstone(tombstoneFile, sessionHash);
+    if (tombstone) {
+      return { status: "expired", reason: tombstone.reason };
+    }
+
     const path = historyPath(this.repository, this.sessionId);
     try {
       const metadata = await stat(path);
-      if (!metadata.isFile() || metadata.size > MAX_HISTORY_BYTES) return null;
+      if (!metadata.isFile() || metadata.size > MAX_HISTORY_BYTES) return { status: "unavailable" };
       const parsed = parseHistory(
         JSON.parse(await readFile(path, "utf8")) as unknown,
         this.sessionId,
         this.repository,
       );
-      if (!parsed) return null;
+      if (!parsed) return { status: "unavailable" };
       const refPrefix = `refs/omp-undo-redo/history/${parsed.sessionHash}/`;
       const refs = await existingRefs(this.git, refPrefix);
-      if (refs === null) return null;
+      if (refs === null) return { status: "unavailable" };
       const checkpoints = parsed.checkpoints.map((checkpoint): TurnCheckpoint => {
         if (checkpoint.kind === "session") return checkpoint;
         if (checkpoint.kind !== "git")
@@ -246,10 +385,13 @@ export class SessionHistoryStore {
         ) ||
         expectedLeaf(state) !== effectiveLeaf(reader)
       )
-        return null;
-      return state;
+        return { status: "unavailable" };
+
+      await this.save(state).catch(() => undefined);
+
+      return { status: "loaded", state };
     } catch {
-      return null;
+      return { status: "unavailable" };
     }
   }
 
@@ -278,11 +420,12 @@ export class SessionHistoryStore {
       };
     });
     const stored: StoredHistory = {
-      schemaVersion: HISTORY_SCHEMA,
+      schemaVersion: HISTORY_SCHEMA_CURRENT,
       sessionHash,
       repository: this.repository,
       checkpoints,
       currentIndex: state.currentIndex,
+      lastAccessedAt: new Date().toISOString(),
     };
     const temporary = join(
       directory,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -26,7 +26,8 @@ export type FileCheckpointUnavailableReason =
   | "workspace_unresolvable"
   | "before_blob_failed"
   | "after_blob_failed"
-  | "blob_apply_failed";
+  | "blob_apply_failed"
+  | "history_expired";
 
 export type TreeNavigationResult = {
   cancelled: boolean;
@@ -159,6 +160,18 @@ export interface PendingSessionCheckpoint {
   reason: FileCheckpointUnavailableReason;
   parentLeafId: string | null;
 }
+
+export interface ExpirationTombstone {
+  expired: true;
+  sessionHash: string;
+  expiredAt: string;
+  reason: "age" | "storage_cap";
+}
+
+export type HistoryLoadResult =
+  | { status: "loaded"; state: NavigationState }
+  | { status: "expired"; reason: "age" | "storage_cap" }
+  | { status: "unavailable" };
 
 export type PendingTurnCheckpoint =
   PendingGitCheckpoint | PendingBlobCheckpoint | PendingSessionCheckpoint;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,11 @@ import {
   resolveRepository,
   retainCheckpointForResume,
 } from "./core/checkpoints.js";
-import { reconstructSessionHistory, SessionHistoryStore } from "./core/history-store.js";
+import {
+  expireGitSessionHistories,
+  reconstructSessionHistory,
+  SessionHistoryStore,
+} from "./core/history-store.js";
 import type {
   ActionId,
   GitRepository,
@@ -63,7 +67,19 @@ type AnyContext = {
     getBranch(fromId?: string): SessionEntryLike[];
     getEntry(id: string): SessionEntryLike | undefined;
   };
+  ui?: {
+    notify(message: string, level: string): void;
+  };
 };
+
+function readRetentionConfig(): { retentionDays: number; maxStoreBytes: number } {
+  const days = parseInt(process.env.OMP_UNDO_REDO_RETENTION_DAYS ?? "", 10);
+  const mb = parseInt(process.env.OMP_UNDO_REDO_MAX_STORE_MB ?? "", 10);
+  return {
+    retentionDays: Number.isFinite(days) && days >= 0 ? days : 2,
+    maxStoreBytes: Number.isFinite(mb) && mb >= 0 ? mb * 1024 * 1024 : 1024 * 1024 * 1024,
+  };
+}
 
 type FileBackend =
   | { kind: "git"; repository: GitRepository; git: ReturnType<typeof createGitRunner> }
@@ -144,6 +160,7 @@ function createNavigation(
 }
 
 export default function ompUndoRedo(pi: ExtensionAPI): void {
+  const retentionConfig = readRetentionConfig();
   const ownerRegistry = new CheckpointOwnerRegistry({
     resolveHostIdentity: resolvePersistentHostId,
     resolveRuntimeScope,
@@ -160,6 +177,25 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
   let shutdownPromise: Promise<void> | null = null;
   let pendingSwitchSourceSessionId: string | null = null;
   let pendingBranchSourceSessionId: string | null = null;
+  const expirationPromises = new Map<string, Promise<void>>();
+  const explicitActiveHashes = new Set<string>();
+
+  function activeSessionHashes(): ReadonlySet<string> {
+    const hashes = new Set<string>();
+    for (const sessionId of navigations.keys()) {
+      hashes.add(checkpointNamespace(sessionId));
+    }
+    for (const sessionId of pending.keys()) {
+      hashes.add(checkpointNamespace(sessionId));
+    }
+    for (const sessionId of initializations.keys()) {
+      hashes.add(checkpointNamespace(sessionId));
+    }
+    for (const hash of explicitActiveHashes) {
+      hashes.add(hash);
+    }
+    return hashes;
+  }
 
   function blobStoreFor(_workspaceRoot: string): BlobStore {
     const root = blobStoreRootDirectory();
@@ -167,7 +203,16 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     if (existing) return existing;
     const store = new BlobStore(root);
     blobStores.set(root, store);
-    void store.garbageCollect().catch(() => undefined);
+    const { retentionDays, maxStoreBytes } = retentionConfig;
+    if (retentionDays > 0 || maxStoreBytes > 0) {
+      const expiration = store
+        .expireAndCollect(retentionDays, maxStoreBytes, () => activeSessionHashes())
+        .catch(() => undefined);
+      expirationPromises.set(`blob:${root}`, expiration);
+    } else {
+      const gc = store.garbageCollect().catch(() => undefined);
+      expirationPromises.set(`blob:${root}`, gc);
+    }
     return store;
   }
 
@@ -176,6 +221,8 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     replaceExisting: boolean,
   ): Promise<SessionNavigation> {
     const sessionId = ctx.sessionManager.getSessionId();
+    const sessionHash = checkpointNamespace(sessionId);
+    explicitActiveHashes.add(sessionHash);
     if (!replaceExisting) {
       const current = navigations.get(sessionId);
       if (current) return current;
@@ -189,6 +236,31 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
       if (previous) await previous.suspend();
       const backend = await resolveBackend(ctx.cwd, (workspaceRoot) => blobStoreFor(workspaceRoot));
       backends.set(sessionId, backend);
+
+      if (
+        backend.kind === "git" &&
+        !expirationPromises.has(`git:${backend.repository.commonDir}`)
+      ) {
+        const { retentionDays } = retentionConfig;
+        const expiration = expireGitSessionHistories(
+          backend.repository,
+          backend.git,
+          retentionDays,
+          () => activeSessionHashes(),
+        ).catch(() => undefined);
+        expirationPromises.set(`git:${backend.repository.commonDir}`, expiration);
+      }
+
+      const expirationKey =
+        backend.kind === "blob"
+          ? `blob:${blobStoreRootDirectory()}`
+          : backend.kind === "git"
+            ? `git:${backend.repository.commonDir}`
+            : undefined;
+      if (expirationKey) {
+        await expirationPromises.get(expirationKey);
+      }
+
       const store =
         backend.kind === "git"
           ? new SessionHistoryStore(sessionId, backend.repository, backend.git)
@@ -196,7 +268,28 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
             ? new BlobHistoryStore(sessionId, backend.workspaceRoot, backend.store)
             : undefined;
       const navigation = createNavigation(ctx, sessionId, store, runtimeStore, backend);
-      const restored = store ? await store.load(ctx.sessionManager) : null;
+      const loadResult = store ? await store.load(ctx.sessionManager) : null;
+      let restored: NavigationState | null = null;
+      if (loadResult?.status === "loaded") {
+        restored = loadResult.state;
+      } else if (loadResult?.status === "expired") {
+        restored = null;
+        if (ctx.ui?.notify) {
+          if (loadResult.reason === "age") {
+            ctx.ui.notify(
+              "Undo/redo file history for this session expired due to inactivity.\nSession navigation still works, but file changes cannot be restored.",
+              "warning",
+            );
+          } else if (loadResult.reason === "storage_cap") {
+            ctx.ui.notify(
+              "Undo/redo file history for this session was removed to free storage space.\nSession navigation still works, but file changes cannot be restored.",
+              "warning",
+            );
+          }
+        }
+      } else {
+        restored = null;
+      }
       navigation.restoreState(restored ?? reconstructSessionHistory(ctx.sessionManager));
       await runtimeStore.initializeSession(
         sessionId,
@@ -507,6 +600,7 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     navigations.clear();
     initializations.clear();
     pending.clear();
+    explicitActiveHashes.clear();
     shutdownPromise = (async () => {
       await disposeDetached(detachedNavigations, detachedPending, false);
       await Promise.allSettled([...activeOperations]);

--- a/test/blob-expiration.test.ts
+++ b/test/blob-expiration.test.ts
@@ -1,0 +1,527 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { BlobHistoryStore, blobTombstonePath } from "../src/core/blob-history-store.js";
+import { BlobStore } from "../src/core/blob-store.js";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function sessionHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("BlobStore expiration and storage cap", () => {
+  it("expires old session histories by age and runs GC", async () => {
+    const workspace = await temporaryDirectory("blob-exp-age-ws-");
+    const storage = await temporaryDirectory("blob-exp-age-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "old-session";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+
+    await writeFile(join(workspace, "file.txt"), "old content");
+    const before = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    const after = await store.captureSnapshot(workspace, hash, checkpointId, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const oldHistoryStore = new BlobHistoryStore(sessionId, workspace, store);
+    await oldHistoryStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: before.treeId,
+          afterTreeId: after.treeId,
+          parentLeafId: "prompt",
+          leafId: "response",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    // Manually overwrite history file to set lastAccessedAt to 40 days ago
+    const historyFilePath = join(storage, "history", `${hash}.json`);
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    const content = JSON.parse(await readFile(historyFilePath, "utf8"));
+    content.lastAccessedAt = oldDate;
+    await writeFile(historyFilePath, JSON.stringify(content));
+
+    // Run expireAndCollect with 30 days retention
+    await store.expireAndCollect(30, 0, new Set());
+
+    // Verify history JSON removed
+    await expect(stat(historyFilePath)).rejects.toThrow();
+
+    // Verify tombstone written
+    const tombFile = blobTombstonePath(sessionId, storage);
+    const tombstone = JSON.parse(await readFile(tombFile, "utf8"));
+    expect(tombstone).toEqual({
+      expired: true,
+      sessionHash: hash,
+      expiredAt: expect.any(String),
+      reason: "age",
+    });
+
+    // Verify blobs were garbage collected
+    expect(await store.treeExists(before.treeId)).toBe(false);
+
+    await store.shutdown();
+  });
+
+  it("evicts oldest sessions when storage cap is exceeded", async () => {
+    const workspace = await temporaryDirectory("blob-exp-cap-ws-");
+    const storage = await temporaryDirectory("blob-exp-cap-store-");
+    const store = new BlobStore(storage);
+
+    const s1 = "session-1";
+    const s2 = "session-2";
+    const s3 = "session-3";
+    const h1 = sessionHash(s1);
+    const h2 = sessionHash(s2);
+    const h3 = sessionHash(s3);
+
+    const setupSession = async (sId: string, h: string, content: string, daysAgo: number) => {
+      const chk = randomUUID();
+      await writeFile(join(workspace, "f.txt"), content);
+      const before = await store.captureSnapshot(workspace, h, chk, "before");
+      const after = await store.captureSnapshot(workspace, h, chk, "after");
+      if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+      await store.retainCheckpointForResume(h, chk);
+
+      const hStore = new BlobHistoryStore(sId, workspace, store);
+      await hStore.save({
+        checkpoints: [
+          {
+            kind: "blob",
+            workspaceRoot: workspace,
+            sessionHash: h,
+            checkpointId: chk,
+            beforeTreeId: before.treeId,
+            afterTreeId: after.treeId,
+            parentLeafId: "p",
+            leafId: "r",
+          },
+        ],
+        currentIndex: 0,
+      });
+
+      const hFile = join(storage, "history", `${h}.json`);
+      const dateStr = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+      const json = JSON.parse(await readFile(hFile, "utf8"));
+      json.lastAccessedAt = dateStr;
+      await writeFile(hFile, JSON.stringify(json));
+    };
+
+    await setupSession(s1, h1, "content session 1 ".repeat(100), 10);
+    const bytes1 = await store.measureStoreBytes();
+    await setupSession(s2, h2, "content session 2 ".repeat(100), 5);
+    await setupSession(s3, h3, "content session 3 ".repeat(100), 1);
+
+    const totalBytes = await store.measureStoreBytes();
+    expect(totalBytes).toBeGreaterThan(0);
+
+    // Set cap so that evicting s1 (oldest) brings size under cap
+    const capBytes = totalBytes - Math.floor(bytes1 / 2);
+
+    await store.expireAndCollect(0, capBytes, new Set());
+
+    // s1 (oldest, 10 days ago) should be evicted first
+    const hFile1 = join(storage, "history", `${h1}.json`);
+    await expect(stat(hFile1)).rejects.toThrow();
+
+    // Verify tombstone reason is storage_cap
+    const tombFile1 = blobTombstonePath(s1, storage);
+    const tomb1 = JSON.parse(await readFile(tombFile1, "utf8"));
+    expect(tomb1.reason).toBe("storage_cap");
+
+    // s2 and s3 should be retained
+    const hFile2 = join(storage, "history", `${h2}.json`);
+    expect((await stat(hFile2)).isFile()).toBe(true);
+    const hFile3 = join(storage, "history", `${h3}.json`);
+    expect((await stat(hFile3)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("never evicts active sessions during cap enforcement", async () => {
+    const workspace = await temporaryDirectory("blob-exp-active-ws-");
+    const storage = await temporaryDirectory("blob-exp-active-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "active-session-cap";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+
+    await writeFile(join(workspace, "f.txt"), "active file content");
+    const snap = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    if ("reason" in snap) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const hStore = new BlobHistoryStore(sessionId, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: snap.treeId,
+          afterTreeId: snap.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    const hFile = join(storage, "history", `${hash}.json`);
+    const oldDate = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString();
+    const json = JSON.parse(await readFile(hFile, "utf8"));
+    json.lastAccessedAt = oldDate;
+    await writeFile(hFile, JSON.stringify(json));
+
+    // Cap is 1 byte, but session is active
+    await store.expireAndCollect(0, 1, new Set([hash]));
+
+    // Active session file must be preserved
+    expect((await stat(hFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("handles deduplication correctly during cap eviction (preserves shared blobs of remaining sessions)", async () => {
+    const workspace = await temporaryDirectory("blob-exp-dedup-ws-");
+    const storage = await temporaryDirectory("blob-exp-dedup-store-");
+    const store = new BlobStore(storage);
+
+    const s1 = "session-dedup-1";
+    const s2 = "session-dedup-2";
+    const h1 = sessionHash(s1);
+    const h2 = sessionHash(s2);
+    const chk1 = randomUUID();
+    const chk2 = randomUUID();
+
+    // Session 1 has shared file
+    await writeFile(
+      join(workspace, "shared.txt"),
+      "identical content shared between sessions ".repeat(50),
+    );
+    const before1 = await store.captureSnapshot(workspace, h1, chk1, "before");
+    const after1 = await store.captureSnapshot(workspace, h1, chk1, "after");
+    if ("reason" in before1 || "reason" in after1) throw new Error("snapshot failed");
+
+    // Session 2 has shared file plus extra unique file so s2 size alone fits in capBytes
+    await writeFile(join(workspace, "unique_s2.txt"), "unique content for session 2 ".repeat(50));
+    const before2 = await store.captureSnapshot(workspace, h2, chk2, "before");
+    const after2 = await store.captureSnapshot(workspace, h2, chk2, "after");
+    if ("reason" in before2 || "reason" in after2) throw new Error("snapshot failed");
+
+    await store.retainCheckpointForResume(h1, chk1);
+    await store.retainCheckpointForResume(h2, chk2);
+
+    const hStore1 = new BlobHistoryStore(s1, workspace, store);
+    await hStore1.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: h1,
+          checkpointId: chk1,
+          beforeTreeId: before1.treeId,
+          afterTreeId: after1.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    const hStore2 = new BlobHistoryStore(s2, workspace, store);
+    await hStore2.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: h2,
+          checkpointId: chk2,
+          beforeTreeId: before2.treeId,
+          afterTreeId: after2.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    // Make s1 older
+    const hFile1 = join(storage, "history", `${h1}.json`);
+    const json1 = JSON.parse(await readFile(hFile1, "utf8"));
+    json1.lastAccessedAt = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(hFile1, JSON.stringify(json1));
+
+    const totalBytes = await store.measureStoreBytes();
+    // Set cap bytes slightly below totalBytes so evicting s1's manifest gets store under cap without evicting s2
+    const capBytes = totalBytes - 50;
+
+    // Force cap eviction of s1
+    await store.expireAndCollect(0, capBytes, new Set());
+
+    // s1 history is deleted
+    await expect(stat(hFile1)).rejects.toThrow();
+
+    // But shared blob still exists because s2 references it!
+    expect(await store.blobExists(before1.entries[0].blobHash)).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("handles mixed age expiration and cap eviction in a single run", async () => {
+    const workspace = await temporaryDirectory("blob-exp-mixed-ws-");
+    const storage = await temporaryDirectory("blob-exp-mixed-store-");
+    const store = new BlobStore(storage);
+
+    const s1 = "session-mixed-1";
+    const s2 = "session-mixed-2";
+    const s3 = "session-mixed-3";
+    const h1 = sessionHash(s1);
+    const h2 = sessionHash(s2);
+    const h3 = sessionHash(s3);
+
+    const setupSession = async (sId: string, h: string, content: string, daysAgo: number) => {
+      const chk = randomUUID();
+      await writeFile(join(workspace, "f.txt"), content);
+      const before = await store.captureSnapshot(workspace, h, chk, "before");
+      const after = await store.captureSnapshot(workspace, h, chk, "after");
+      if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+      await store.retainCheckpointForResume(h, chk);
+
+      const hStore = new BlobHistoryStore(sId, workspace, store);
+      await hStore.save({
+        checkpoints: [
+          {
+            kind: "blob",
+            workspaceRoot: workspace,
+            sessionHash: h,
+            checkpointId: chk,
+            beforeTreeId: before.treeId,
+            afterTreeId: after.treeId,
+            parentLeafId: "p",
+            leafId: "r",
+          },
+        ],
+        currentIndex: 0,
+      });
+
+      const hFile = join(storage, "history", `${h}.json`);
+      const dateStr = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+      const json = JSON.parse(await readFile(hFile, "utf8"));
+      json.lastAccessedAt = dateStr;
+      await writeFile(hFile, JSON.stringify(json));
+    };
+
+    // s1 is 40 days old (expires by age 30)
+    await setupSession(s1, h1, "content 1 ".repeat(100), 40);
+    // s2 is 10 days old (within age, but will be evicted by tight cap)
+    await setupSession(s2, h2, "content 2 ".repeat(100), 10);
+    const bytesAfterS2 = await store.measureStoreBytes();
+    // s3 is 1 day old (newest)
+    await setupSession(s3, h3, "content 3 ".repeat(100), 1);
+
+    // Set cap so that after s1 is expired by age, remaining store size > cap, forcing s2 eviction
+    const capBytes = bytesAfterS2 - Math.floor((bytesAfterS2 - 0) / 4);
+
+    await store.expireAndCollect(30, capBytes, new Set());
+
+    // s1 tombstone should be "age"
+    const tomb1 = JSON.parse(await readFile(blobTombstonePath(s1, storage), "utf8"));
+    expect(tomb1.reason).toBe("age");
+
+    // s2 tombstone should be "storage_cap"
+    const tomb2 = JSON.parse(await readFile(blobTombstonePath(s2, storage), "utf8"));
+    expect(tomb2.reason).toBe("storage_cap");
+
+    // s3 history remains
+    const hFile3 = join(storage, "history", `${h3}.json`);
+    expect((await stat(hFile3)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("skips cap eviction when maxStoreBytes is 0", async () => {
+    const workspace = await temporaryDirectory("blob-exp-nocap-ws-");
+    const storage = await temporaryDirectory("blob-exp-nocap-store-");
+    const store = new BlobStore(storage);
+
+    const s1 = "session-nocap";
+    const h1 = sessionHash(s1);
+    const chk1 = randomUUID();
+
+    await writeFile(join(workspace, "f.txt"), "some content");
+    const snap = await store.captureSnapshot(workspace, h1, chk1, "before");
+    if ("reason" in snap) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(h1, chk1);
+
+    const hStore = new BlobHistoryStore(s1, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: h1,
+          checkpointId: chk1,
+          beforeTreeId: snap.treeId,
+          afterTreeId: snap.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    await store.expireAndCollect(0, 0, new Set());
+
+    const hFile = join(storage, "history", `${h1}.json`);
+    expect((await stat(hFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("skips malformed history JSON without deleting or crashing", async () => {
+    const storage = await temporaryDirectory("blob-exp-malformed-store-");
+    const store = new BlobStore(storage);
+
+    const h1 = sessionHash("malformed");
+    const historyDir = join(storage, "history");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(historyDir, { recursive: true });
+    const hFile = join(historyDir, `${h1}.json`);
+    await writeFile(hFile, "{ malformed content...", { flag: "w" });
+
+    await store.expireAndCollect(30, 1, new Set());
+
+    expect((await stat(hFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("falls back to file mtime when lastAccessedAt is missing (v1 schema)", async () => {
+    const workspace = await temporaryDirectory("blob-exp-mtime-ws-");
+    const storage = await temporaryDirectory("blob-exp-mtime-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "v1-blob-session";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+
+    await writeFile(join(workspace, "f.txt"), "v1 content");
+    const before = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    const after = await store.captureSnapshot(workspace, hash, checkpointId, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const hStore = new BlobHistoryStore(sessionId, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: before.treeId,
+          afterTreeId: after.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    const hFile = join(storage, "history", `${hash}.json`);
+    const json = JSON.parse(await readFile(hFile, "utf8"));
+    delete json.lastAccessedAt;
+    json.schemaVersion = 1;
+    await writeFile(hFile, JSON.stringify(json));
+
+    const fortyDaysAgoSec = (Date.now() - 40 * 24 * 60 * 60 * 1000) / 1000;
+    const { utimes } = await import("node:fs/promises");
+    await utimes(hFile, fortyDaysAgoSec, fortyDaysAgoSec);
+
+    await store.expireAndCollect(30, 0, new Set());
+
+    await expect(stat(hFile)).rejects.toThrow();
+
+    await store.shutdown();
+  });
+
+  it("uses dynamic activeSessionHashes getter to re-check candidate sessions at deletion time", async () => {
+    const workspace = await temporaryDirectory("blob-exp-getter-ws-");
+    const storage = await temporaryDirectory("blob-exp-getter-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "getter-session";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+
+    await writeFile(join(workspace, "f.txt"), "content");
+    const before = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    const after = await store.captureSnapshot(workspace, hash, checkpointId, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const hStore = new BlobHistoryStore(sessionId, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: before.treeId,
+          afterTreeId: after.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    const hFile = join(storage, "history", `${hash}.json`);
+    const json = JSON.parse(await readFile(hFile, "utf8"));
+    json.lastAccessedAt = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(hFile, JSON.stringify(json));
+
+    const activeSet = new Set<string>();
+    let calls = 0;
+    const activeGetter = () => {
+      calls++;
+      if (calls > 1) activeSet.add(hash);
+      return activeSet;
+    };
+
+    await store.expireAndCollect(30, 0, activeGetter);
+
+    expect((await stat(hFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+});

--- a/test/blob-history-store.test.ts
+++ b/test/blob-history-store.test.ts
@@ -78,8 +78,11 @@ describe("blob history store", () => {
     await expect(
       new BlobHistoryStore(sessionId, workspace, secondStore).load(reader()),
     ).resolves.toEqual({
-      checkpoints: [checkpoint],
-      currentIndex: 0,
+      status: "loaded",
+      state: {
+        checkpoints: [checkpoint],
+        currentIndex: 0,
+      },
     });
     await secondStore.shutdown();
   });
@@ -112,8 +115,11 @@ describe("blob history store", () => {
     const treeUsable = vi.spyOn(store, "treeUsable");
 
     await expect(history.load(reader())).resolves.toEqual({
-      checkpoints: [checkpoint],
-      currentIndex: 0,
+      status: "loaded",
+      state: {
+        checkpoints: [checkpoint],
+        currentIndex: 0,
+      },
     });
     expect(treeUsable).toHaveBeenCalledTimes(1);
     await store.shutdown();
@@ -147,16 +153,49 @@ describe("blob history store", () => {
     await rm(join(storage, "trees", `${before.treeId}.json`), { force: true });
 
     await expect(history.load(reader())).resolves.toEqual({
-      checkpoints: [
-        {
-          kind: "session",
-          reason: "resumed_checkpoint_unavailable",
-          parentLeafId: "prompt",
-          leafId: "response",
-        },
-      ],
-      currentIndex: 0,
+      status: "loaded",
+      state: {
+        checkpoints: [
+          {
+            kind: "session",
+            reason: "resumed_checkpoint_unavailable",
+            parentLeafId: "prompt",
+            leafId: "response",
+          },
+        ],
+        currentIndex: 0,
+      },
     });
+    await store.shutdown();
+  });
+
+  it("returns status expired when tombstone file exists", async () => {
+    const workspace = await temporaryDirectory("omp-blob-tombstone-workspace-");
+    const storage = await temporaryDirectory("omp-blob-tombstone-storage-");
+    const sessionId = "tombstone-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const store = new BlobStore(storage);
+
+    const historyDir = join(storage, "history");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(historyDir, { recursive: true });
+
+    await writeFile(
+      join(historyDir, `${sessionHash}.expired.json`),
+      JSON.stringify({
+        expired: true,
+        sessionHash,
+        expiredAt: new Date().toISOString(),
+        reason: "age",
+      }),
+    );
+
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    await expect(history.load(reader())).resolves.toEqual({
+      status: "expired",
+      reason: "age",
+    });
+
     await store.shutdown();
   });
 });

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -540,4 +540,43 @@ describe("non-Git blob store", () => {
     expect(await store.treeExists(orphan.treeId)).toBe(false);
     await store.shutdown();
   });
+
+  it("measures store bytes correctly", async () => {
+    const workspace = await temporaryDirectory("omp-blob-measure-workspace-");
+    const storage = await temporaryDirectory("omp-blob-measure-storage-");
+    const store = new BlobStore(storage);
+    const session = sessionHash("measure");
+    const checkpoint = randomUUID();
+
+    expect(await store.measureStoreBytes()).toBe(0);
+
+    await writeFile(join(workspace, "measure.txt"), "hello world");
+    const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in snapshot) throw new Error("snapshot failed");
+
+    const bytes = await store.measureStoreBytes();
+    expect(bytes).toBeGreaterThan(0);
+    await store.shutdown();
+  });
+
+  it("releases all session refs", async () => {
+    const workspace = await temporaryDirectory("omp-blob-release-workspace-");
+    const storage = await temporaryDirectory("omp-blob-release-storage-");
+    const store = new BlobStore(storage);
+    const session = sessionHash("release");
+    const checkpoint = randomUUID();
+
+    await writeFile(join(workspace, "release.txt"), "content");
+    const before = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    const after = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(session, checkpoint);
+
+    expect(await store.hasHistoryRef(session, checkpoint, "before")).toBe(true);
+
+    const released = await store.releaseSessionRefs(session);
+    expect(released).toBe(true);
+    expect(await store.hasHistoryRef(session, checkpoint, "before")).toBe(false);
+    await store.shutdown();
+  });
 });

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -1029,4 +1029,98 @@ describe("history-safe Git checkpoints", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("handles HistoryLoadResult, tombstone detection, and schema v1 to v2 upgrade in SessionHistoryStore", async () => {
+    const { cwd, git } = await makeRepo();
+    const repository = {
+      worktree: cwd,
+      gitDir: join(cwd, ".git"),
+      commonDir: join(cwd, ".git"),
+    };
+    const sessionId = "chk-schema-session";
+    const prompt: SessionEntryLike = {
+      id: "p1",
+      parentId: null,
+      type: "message",
+      message: { role: "user" },
+    };
+    const response: SessionEntryLike = {
+      id: "r1",
+      parentId: "p1",
+      type: "message",
+      message: { role: "assistant" },
+    };
+
+    try {
+      await initializeBranch(git, cwd);
+      const { SessionHistoryStore, historyPath, tombstonePath } =
+        await import("../src/core/history-store.js");
+      const store = new SessionHistoryStore(sessionId, repository, git);
+      const r = reader([prompt, response], "r1");
+
+      // 1. Load empty -> returns status: "unavailable"
+      await expect(store.load(r)).resolves.toEqual({ status: "unavailable" });
+
+      // 2. Write schema v1 file without lastAccessedAt
+      const hPath = historyPath(repository, sessionId);
+      await mkdir(join(repository.commonDir, "omp-undo-redo", "history"), { recursive: true });
+      await writeFile(
+        hPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          sessionHash: checkpointNamespace(sessionId),
+          repository,
+          checkpoints: [
+            {
+              kind: "session",
+              reason: "resumed_checkpoint_unavailable",
+              parentLeafId: "p1",
+              leafId: "r1",
+            },
+          ],
+          currentIndex: 0,
+        }),
+      );
+
+      // 3. Load accepts schema v1, returns status: "loaded", and re-saves as v2 with lastAccessedAt
+      const loaded = await store.load(r);
+      expect(loaded).toMatchObject({
+        status: "loaded",
+        state: {
+          currentIndex: 0,
+          checkpoints: [
+            {
+              kind: "session",
+              reason: "resumed_checkpoint_unavailable",
+              parentLeafId: "p1",
+              leafId: "r1",
+            },
+          ],
+        },
+      });
+
+      // Verify JSON was upgraded to schemaVersion 2 with lastAccessedAt
+      const upgradedContent = JSON.parse(await readFile(hPath, "utf8"));
+      expect(upgradedContent.schemaVersion).toBe(2);
+      expect(typeof upgradedContent.lastAccessedAt).toBe("string");
+
+      // 4. Tombstone detection -> load() returns status: "expired"
+      await writeFile(
+        tombstonePath(repository, sessionId),
+        JSON.stringify({
+          expired: true,
+          sessionHash: checkpointNamespace(sessionId),
+          expiredAt: new Date().toISOString(),
+          reason: "age",
+        }),
+      );
+
+      await expect(store.load(r)).resolves.toEqual({
+        status: "expired",
+        reason: "age",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/history-expiration.test.ts
+++ b/test/history-expiration.test.ts
@@ -1,0 +1,307 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  expireGitSessionHistories,
+  historyPath,
+  tombstonePath,
+} from "../src/core/history-store.js";
+import type { GitRepository, GitRunner } from "../src/core/types.js";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function sessionHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("expireGitSessionHistories", () => {
+  it("cleans up an expired session (refs deleted, history JSON deleted, tombstone written)", async () => {
+    const gitDir = await temporaryDirectory("git-expire-1-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "expired-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+
+    const deletedRefs: string[] = [];
+    const dummyGit: GitRunner = async (args, options) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: `refs/omp-undo-redo/history/${hash}/chk1/before\0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (args[0] === "update-ref" && args[1] === "--stdin") {
+        deletedRefs.push(options?.stdin ?? "");
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    // Verify history file is deleted
+    await expect(stat(historyFile)).rejects.toThrow();
+
+    // Verify tombstone is written
+    const tombFile = tombstonePath(repository, sessionId);
+    const tombstoneContent = JSON.parse(await readFile(tombFile, "utf8"));
+    expect(tombstoneContent).toEqual({
+      expired: true,
+      sessionHash: hash,
+      expiredAt: expect.any(String),
+      reason: "age",
+    });
+
+    // Verify ref deletion command was sent with expected hash
+    expect(
+      deletedRefs.some((line) =>
+        line.includes(
+          `delete refs/omp-undo-redo/history/${hash}/chk1/before a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0`,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves active sessions", async () => {
+    const gitDir = await temporaryDirectory("git-expire-active-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "active-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set([hash]));
+
+    const metadata = await stat(historyFile);
+    expect(metadata.isFile()).toBe(true);
+  });
+
+  it("preserves recent sessions", async () => {
+    const gitDir = await temporaryDirectory("git-expire-recent-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "recent-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const recentDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: recentDate,
+      }),
+    );
+
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    const metadata = await stat(historyFile);
+    expect(metadata.isFile()).toBe(true);
+  });
+
+  it("skips malformed history JSON without deleting or crashing", async () => {
+    const gitDir = await temporaryDirectory("git-expire-malformed-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "malformed-session";
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    await writeFile(historyFile, "{ invalid json...");
+
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    const metadata = await stat(historyFile);
+    expect(metadata.isFile()).toBe(true);
+  });
+
+  it("falls back to file mtime when lastAccessedAt is missing (v1 schema)", async () => {
+    const gitDir = await temporaryDirectory("git-expire-v1-fallback-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "v1-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+      }),
+    );
+
+    // Set mtime to 40 days ago
+    const fortyDaysAgo = (Date.now() - 40 * 24 * 60 * 60 * 1000) / 1000;
+    await utimes(historyFile, fortyDaysAgo, fortyDaysAgo);
+
+    const dummyGit: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") return { stdout: "", stderr: "", code: 0 };
+      if (args[0] === "update-ref") return { stdout: "", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    await expect(stat(historyFile)).rejects.toThrow();
+  });
+
+  it("preserves history JSON if ref deletion fails (fail closed)", async () => {
+    const gitDir = await temporaryDirectory("git-expire-ref-fail-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "ref-fail-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+
+    const dummyGit: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: `refs/omp-undo-redo/history/${hash}/chk1/before\0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (args[0] === "update-ref") {
+        return { stdout: "", stderr: "fatal: ref deletion error", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    const metadata = await stat(historyFile);
+    expect(metadata.isFile()).toBe(true);
+  });
+
+  it("skips age expiration when retentionDays=0", async () => {
+    const gitDir = await temporaryDirectory("git-expire-zero-retention-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "zero-retention-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+
+    await expireGitSessionHistories(repository, dummyGit, 0, new Set());
+
+    const metadata = await stat(historyFile);
+    expect(metadata.isFile()).toBe(true);
+  });
+
+  it("returns status expired when tombstone file exists for Git store load", async () => {
+    const gitDir = await temporaryDirectory("git-load-tombstone-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "git-tombstone-session";
+    const hash = sessionHash(sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    await writeFile(
+      tombstonePath(repository, sessionId),
+      JSON.stringify({
+        expired: true,
+        sessionHash: hash,
+        expiredAt: new Date().toISOString(),
+        reason: "storage_cap",
+      }),
+    );
+
+    const { SessionHistoryStore } = await import("../src/core/history-store.js");
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+    const store = new SessionHistoryStore(sessionId, repository, dummyGit);
+
+    const dummyReader = {
+      getLeafId: () => null,
+      getBranch: () => [],
+      getEntry: () => undefined,
+    };
+
+    await expect(store.load(dummyReader)).resolves.toEqual({
+      status: "expired",
+      reason: "storage_cap",
+    });
+  });
+});

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -601,6 +601,102 @@ describe("resumed session history", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("handles session history expiration on session_start and notifies user", async () => {
+    const cwd = await makeRepository();
+    const sessionId1 = "expired-lifecycle-session-1";
+    const sessionId2 = "active-lifecycle-session-2";
+    const prompt: TestEntry = {
+      id: "prompt",
+      parentId: null,
+      type: "message",
+      message: { role: "user" },
+    };
+    const response: TestEntry = {
+      id: "response",
+      parentId: prompt.id,
+      type: "message",
+      message: { role: "assistant" },
+    };
+
+    try {
+      const originalEnv = process.env.OMP_UNDO_REDO_RETENTION_DAYS;
+      process.env.OMP_UNDO_REDO_RETENTION_DAYS = "30";
+
+      // 1. Initial run for session 1: create a turn checkpoint
+      const firstApi = new FakeExtensionApi();
+      ompUndoRedo(firstApi as never);
+      const firstCtx = context(cwd, sessionId1);
+      firstCtx.leaf = prompt.id;
+      firstCtx.branch = [prompt];
+      firstCtx.entries = [prompt];
+
+      await firstApi.emit("session_start", firstCtx);
+      await firstApi.emit("before_agent_start", firstCtx);
+      await writeFile(join(cwd, "tracked.txt"), "changed\n");
+      firstCtx.leaf = response.id;
+      firstCtx.branch = [prompt, response];
+      firstCtx.entries = [prompt, response];
+      await firstApi.emit("agent_end", firstCtx);
+      await firstApi.emit("session_shutdown", firstCtx);
+
+      // 2. Overwrite history file timestamp for session 1 to 40 days ago
+      const { historyPath } = await import("../src/core/history-store.js");
+      const repo = {
+        worktree: cwd,
+        gitDir: join(cwd, ".git"),
+        commonDir: join(cwd, ".git"),
+      };
+      const hPath = historyPath(repo, sessionId1);
+      const content = JSON.parse(await readFile(hPath, "utf8"));
+      content.lastAccessedAt = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+      await writeFile(hPath, JSON.stringify(content));
+
+      // 3. Start session 2 to trigger background expiration of dormant session 1
+      const secondApi = new FakeExtensionApi();
+      ompUndoRedo(secondApi as never);
+      const secondCtx = context(cwd, sessionId2);
+      await secondApi.emit("session_start", secondCtx);
+
+      // 4. Resume session 1 (now expired)
+      const resumeCtx = context(cwd, sessionId1);
+      resumeCtx.leaf = response.id;
+      resumeCtx.branch = [prompt, response];
+      resumeCtx.entries = [prompt, response];
+      resumeCtx.navigateTree = async (targetId) => {
+        resumeCtx.leaf = targetId;
+        resumeCtx.branch = [prompt];
+        return { cancelled: false };
+      };
+
+      await secondApi.emit("session_start", resumeCtx);
+
+      // Verify expiration notification was shown on resume
+      expect(
+        resumeCtx.ui.notifications.some((n) =>
+          n.message.includes("Undo/redo file history for this session expired"),
+        ),
+      ).toBe(true);
+
+      // Run undo on resumed session 1
+      await secondApi.runCommand("undo", resumeCtx);
+      expect(resumeCtx.leaf).toBe(prompt.id);
+      expect(resumeCtx.ui.notifications.at(-1)?.message).toBe(
+        "Undid the session turn, but files were not restored because the resumed turn has no usable file checkpoint.",
+      );
+
+      await secondApi.emit("session_shutdown", secondCtx);
+      await secondApi.emit("session_shutdown", resumeCtx);
+
+      if (originalEnv !== undefined) {
+        process.env.OMP_UNDO_REDO_RETENTION_DAYS = originalEnv;
+      } else {
+        delete process.env.OMP_UNDO_REDO_RETENTION_DAYS;
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("extension lifecycle cleanup", () => {


### PR DESCRIPTION
## Summary
- expire dormant Git and non-Git snapshot histories
- enforce non-Git blob-store storage cap
- track last access with schema v2 and tombstones
- document retention configuration and release v1.3.0

## Verification
- npm run verify
- 128 tests passed, 4 skipped
- npm package check passed for 1.3.0