### PR TITLE
perf: optimize blob workspace walk and add capture benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.3.1] - 2026-08-13
+
+### Performance
+
+- Drop the per-entry `realpath` from non-Git workspace walks; storage-root containment is now a normalized string-prefix comparison against canonical roots, with `realpath` retained only for the rare symbolic-link entries whose true target can diverge from their name path.
+- Replace per-directory stat batches with a single global concurrency limit (`walkConcurrency` option on `BlobStore`, default `16`, capped at `64`), overlapping directory reads and per-file metadata stats across the whole tree without multiplying through depth.
+- Skip the tree-manifest rewrite and its `exists` probe when the captured tree ID matches the validated workspace cache, and write the on-disk manifest from the already-hashed canonical string instead of serializing the entries a second time.
+- Add `npm run bench:walk` (`scripts/bench-walk.mjs`) to measure cold, warm, and incremental non-Git captures on a synthetic workspace.
+
 ## [1.3.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Install dependencies with npm, then use the scripts in `package.json`:
 - `npm test` runs the deterministic test suite.
 - `npm run lint` and `npm run format:check` check style.
 - `npm run verify` runs the repository verification sequence.
+- `npm run bench:walk` benchmarks non-Git blob-store captures (cold, warm cache-hit, and incremental) on a synthetic workspace under the OS temp directory.
 
 The implementation uses only public OMP extension APIs. Keep changes focused, preserve the package manifest, and do not commit generated `dist/` output unless a release process explicitly requires it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [
@@ -42,6 +42,7 @@
   ],
   "scripts": {
     "clean": "node scripts/clean-dist.mjs",
+    "bench:walk": "npm run build && node scripts/bench-walk.mjs",
     "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.json",
     "postbuild": "node scripts/check-dist.mjs",

--- a/scripts/bench-walk.mjs
+++ b/scripts/bench-walk.mjs
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { BlobStore } from "../dist/core/blob-store.js";
+
+const [fileCountRaw, directoryCountRaw, concurrencyRaw] = process.argv.slice(2);
+const fileCount = Number.parseInt(fileCountRaw ?? "20000", 10);
+const directoryCount = Number.parseInt(directoryCountRaw ?? "400", 10);
+const concurrency = Number.parseInt(concurrencyRaw ?? "16", 10);
+const filesPerDirectory = Math.max(1, Math.floor(fileCount / Math.max(1, directoryCount)));
+
+function formatMilliseconds(value) {
+  return `${value.toFixed(1)} ms`;
+}
+
+async function main() {
+  const root = await mkdtemp(join(tmpdir(), "omp-undo-redo-bench-"));
+  try {
+    const storage = join(root, "storage");
+    const workspace = join(root, "workspace");
+    const store = new BlobStore(storage, { walkConcurrency: concurrency });
+    const session = "0".repeat(64);
+    const checkpoint = "c0ffee";
+
+    const created = performance.now();
+    let written = 0;
+    for (let dir = 0; dir < directoryCount; dir += 1) {
+      const directory = join(workspace, `d${dir}`);
+      await mkdir(directory, { recursive: true });
+      for (let file = 0; file < filesPerDirectory; file += 1) {
+        await writeFile(join(directory, `f${file}.txt`), `content-${dir}-${file}\n`);
+        written += 1;
+      }
+    }
+    console.log(
+      `created ${written} files in ${directoryCount} directories (${formatMilliseconds(
+        performance.now() - created,
+      )})`,
+    );
+
+    const coldStart = performance.now();
+    const cold = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in cold) throw new Error(`cold capture failed: ${cold.reason}`);
+    console.log(
+      `cold capture (read+hash+write blobs): ${formatMilliseconds(performance.now() - coldStart)}`,
+    );
+
+    const warmStart = performance.now();
+    const warm = await store.captureSnapshot(workspace, session, checkpoint, "after");
+    if ("reason" in warm) throw new Error(`warm capture failed: ${warm.reason}`);
+    console.log(
+      `warm capture (cache hit, no changes): ${formatMilliseconds(performance.now() - warmStart)}`,
+    );
+    if (warm.treeId !== cold.treeId) throw new Error("unchanged workspace produced a new treeId");
+
+    const touch = join(workspace, "d0", "f0.txt");
+    await writeFile(touch, `content-0-0-modified-${Date.now()}\n`);
+    const incrementalStart = performance.now();
+    const incremental = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in incremental)
+      throw new Error(`incremental capture failed: ${incremental.reason}`);
+    console.log(
+      `incremental capture (1 file changed): ${formatMilliseconds(
+        performance.now() - incrementalStart,
+      )}`,
+    );
+
+    console.log(`entries: ${cold.entries.length}, skipped: ${cold.skippedPaths.length}`);
+    await store.shutdown();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -77,6 +77,8 @@ const MAX_CACHED_WORKSPACES = 16;
 const MAX_CACHED_FILES_PER_WORKSPACE = 100_000;
 const MAX_CACHED_FILES = 100_000;
 const RACILY_CLEAN_MS = 4_000;
+const DEFAULT_WALK_CONCURRENCY = 16;
+const MAX_WALK_CONCURRENCY = 64;
 
 export function blobStoreRootDirectory(): string {
   if (process.env.OMP_UNDO_REDO_BLOB_DIR) return resolve(process.env.OMP_UNDO_REDO_BLOB_DIR);
@@ -167,10 +169,12 @@ export class BlobStore {
   private readonly ignore: ReadonlySet<string>;
   private readonly clock: () => Date;
   private readonly readWorkspaceFile: (path: string) => Promise<Buffer>;
+  private readonly walkConcurrency: number;
   private readonly locks = new Map<string, Promise<void>>();
   private readonly ownerId = randomUUID();
   private leasePublished = false;
   private readonly workspaceCaches = new Map<string, WorkspaceCache>();
+  private storageRoot: Promise<string> | null = null;
 
   constructor(
     readonly rootDirectory: string,
@@ -179,6 +183,7 @@ export class BlobStore {
       ignore?: readonly string[];
       clock?: () => Date;
       readWorkspaceFile?: (path: string) => Promise<Buffer>;
+      walkConcurrency?: number;
     } = {},
   ) {
     this.rootDirectory = resolve(rootDirectory);
@@ -186,6 +191,10 @@ export class BlobStore {
     this.ignore = new Set(options.ignore ?? DEFAULT_BLOB_IGNORES);
     this.clock = options.clock ?? (() => new Date());
     this.readWorkspaceFile = options.readWorkspaceFile ?? readFile;
+    this.walkConcurrency = Math.max(
+      1,
+      Math.min(options.walkConcurrency ?? DEFAULT_WALK_CONCURRENCY, MAX_WALK_CONCURRENCY),
+    );
   }
 
   private blobPath(hash: string): string {
@@ -327,6 +336,10 @@ export class BlobStore {
     return { hash: hash.digest("hex") };
   }
 
+  private manifestFileContent(manifest: TreeManifest, canonical: string): string {
+    return `{"treeId":${JSON.stringify(manifest.treeId)},${canonical.slice(1)}`;
+  }
+
   private cacheWorkspace(
     workspaceRoot: string,
     treeId: string,
@@ -351,6 +364,11 @@ export class BlobStore {
     }
   }
 
+  private canonicalStorageRoot(): Promise<string> {
+    this.storageRoot ??= realpath(this.rootDirectory).catch(() => resolve(this.rootDirectory));
+    return this.storageRoot;
+  }
+
   private async walkWorkspace(
     workspaceRoot: string,
     cachedFiles: ReadonlyMap<string, CachedWorkspaceFile> | undefined,
@@ -363,63 +381,136 @@ export class BlobStore {
     const entries: TreeEntry[] = [];
     const skippedPaths: string[] = [];
     const files = new Map<string, CachedWorkspaceFile>();
-    const storageRoot = await realpath(this.rootDirectory).catch(() => resolve(this.rootDirectory));
+    // Storage-root containment without a per-entry realpath: workspaceRoot and the
+    // storage root are both canonical (resolved by captureSnapshot and
+    // canonicalStorageRoot), and entries are walked by name, so a normalized
+    // string-prefix comparison is equivalent to resolving every path. Symbolic
+    // links are the only entries whose true target can diverge from their name
+    // path, so they keep the (rare) realpath check below.
+    const storageRoot = await this.canonicalStorageRoot();
     const normalized = (value: string) =>
       process.platform === "win32" ? value.toLowerCase() : value;
     const normalizedStorageRoot = normalized(storageRoot);
+    if (normalized(workspaceRoot) === normalizedStorageRoot) {
+      // Degenerate configuration: the workspace root IS the blob store. Capturing
+      // the store's own blobs/trees/refs would pollute the tree, so the historical
+      // per-entry containment check yielded an empty snapshot; preserve that.
+      return { entries, skippedPaths, files };
+    }
+    const storageRelative = relative(workspaceRoot, storageRoot);
+    const storagePrefix =
+      storageRelative && !storageRelative.startsWith("..") && !isAbsolute(storageRelative)
+        ? normalized(storageRelative.split(sep).join("/"))
+        : null;
+    const underStorageRoot = (value: string): boolean => {
+      const resolved = normalized(value);
+      return (
+        resolved === normalizedStorageRoot || resolved.startsWith(`${normalizedStorageRoot}${sep}`)
+      );
+    };
+
+    // A single global concurrency limit for the whole tree. A per-directory batch
+    // would multiply through depth (C workers per directory -> C^depth in flight).
+    // There is no sound shortcut that skips the per-file lstat pass: a directory's
+    // mtime/ctime changes only on entry add/remove/rename — in-place content
+    // rewrites (the case the racily-clean guard protects) leave it untouched — so
+    // an "unchanged directory" cannot prove its files unchanged.
+    const queue: Array<() => Promise<void>> = [];
+    let head = 0;
+    let running = 0;
+    let pending = 0;
+    let failure: unknown = null;
+    let resolveDrained!: () => void;
+    const drained = new Promise<void>((resolve) => {
+      resolveDrained = resolve;
+    });
+    const pump = (): void => {
+      while (running < this.walkConcurrency && head < queue.length) {
+        const task = queue[head];
+        head += 1;
+        running += 1;
+        void task()
+          .catch((error: unknown) => {
+            failure ??= error;
+          })
+          .finally(() => {
+            running -= 1;
+            pending -= 1;
+            if (head === queue.length) {
+              queue.length = 0;
+              head = 0;
+            }
+            if (pending === 0) resolveDrained();
+            else pump();
+          });
+      }
+    };
+    const enqueue = (task: () => Promise<void>): void => {
+      pending += 1;
+      queue.push(task);
+      pump();
+    };
+
+    const processFile = async (fullPath: string, relativePath: string): Promise<void> => {
+      const metadata = await lstat(fullPath);
+      if (metadata.size > this.maxFileBytes) {
+        skippedPaths.push(relativePath);
+        return;
+      }
+      const fingerprint = fileFingerprint(metadata);
+      const cached = cachedFiles?.get(relativePath);
+      if (cached && sameFingerprint(cached.fingerprint, fingerprint)) {
+        // Racily-clean guard: a same-size in-place rewrite that lands inside the
+        // filesystem's timestamp resolution window (≤2 s on FAT/SMB) produces an
+        // identical fingerprint.  We compare the file's mtime against the *prior*
+        // capture's wall-clock — the window that matters is whether the file was
+        // touched close to when we last observed it.  Two tick-widths (4 s) closes
+        // the coarse-tick corner on FAT where a rewrite and the prior observation
+        // land on the same tick.
+        const racilyClean = Math.abs(cached.fingerprint.mtimeMs - guardTime) < RACILY_CLEAN_MS;
+        if (!racilyClean) {
+          entries.push(cached.entry);
+          files.set(relativePath, cached);
+          return;
+        }
+      }
+      const content = await this.readWorkspaceFile(fullPath);
+      const hash = sha256(content);
+      await this.writeBlob(hash, content);
+      const entry = { path: relativePath, blobHash: hash, mode: fingerprint.mode };
+      entries.push(entry);
+      files.set(relativePath, { fingerprint, entry });
+    };
+
     const walk = async (directory: string, relativeDirectory: string): Promise<void> => {
       const children = await readdir(directory, { withFileTypes: true });
       for (const child of children) {
         if (this.ignore.has(child.name)) continue;
         const relativePath = relativeDirectory ? `${relativeDirectory}/${child.name}` : child.name;
         const fullPath = join(directory, child.name);
-        const normalizedFullPath = normalized(
-          await realpath(fullPath).catch(() => resolve(fullPath)),
-        );
+        const normalizedRelativePath = normalized(relativePath);
         if (
-          normalizedFullPath === normalizedStorageRoot ||
-          normalizedFullPath.startsWith(`${normalizedStorageRoot}${sep}`)
+          storagePrefix !== null &&
+          (normalizedRelativePath === storagePrefix ||
+            normalizedRelativePath.startsWith(`${storagePrefix}/`))
         )
           continue;
         if (child.isDirectory()) {
-          await walk(fullPath, relativePath);
+          enqueue(() => walk(fullPath, relativePath));
         } else if (child.isSymbolicLink()) {
-          skippedPaths.push(relativePath);
+          const resolved = await realpath(fullPath).catch(() => resolve(fullPath));
+          if (!underStorageRoot(resolved)) skippedPaths.push(relativePath);
         } else if (child.isFile()) {
-          const metadata = await lstat(fullPath);
-          if (metadata.size > this.maxFileBytes) {
-            skippedPaths.push(relativePath);
-            continue;
-          }
-          const fingerprint = fileFingerprint(metadata);
-          const cached = cachedFiles?.get(relativePath);
-          if (cached && sameFingerprint(cached.fingerprint, fingerprint)) {
-            // Racily-clean guard: a same-size in-place rewrite that lands inside the
-            // filesystem's timestamp resolution window (≤2 s on FAT/SMB) produces an
-            // identical fingerprint.  We compare the file's mtime against the *prior*
-            // capture's wall-clock — the window that matters is whether the file was
-            // touched close to when we last observed it.  Two tick-widths (4 s) closes
-            // the coarse-tick corner on FAT where a rewrite and the prior observation
-            // land on the same tick.
-            const racilyClean = Math.abs(cached.fingerprint.mtimeMs - guardTime) < RACILY_CLEAN_MS;
-            if (!racilyClean) {
-              entries.push(cached.entry);
-              files.set(relativePath, cached);
-              continue;
-            }
-          }
-          const content = await this.readWorkspaceFile(fullPath);
-          const hash = sha256(content);
-          await this.writeBlob(hash, content);
-          const entry = { path: relativePath, blobHash: hash, mode: fingerprint.mode };
-          entries.push(entry);
-          files.set(relativePath, { fingerprint, entry });
+          enqueue(() => processFile(fullPath, relativePath));
         } else {
           skippedPaths.push(relativePath);
         }
       }
     };
-    await walk(workspaceRoot, "");
+
+    enqueue(() => walk(workspaceRoot, ""));
+    await drained;
+    if (failure) throw failure;
     return { entries, skippedPaths, files };
   }
 
@@ -569,7 +660,14 @@ export class BlobStore {
           skippedPaths: walked.skippedPaths,
         };
         const treePath = this.treePath(treeId);
-        if (!(await exists(treePath))) await this.atomicWrite(treePath, JSON.stringify(manifest));
+        if (!(cache && cachedFiles && cache.treeId === treeId)) {
+          // When the treeId matches the validated cache, the tree file was verified
+          // present above and GC shares this lock, so no exists() check or rewrite
+          // is needed.
+          if (!(await exists(treePath))) {
+            await this.atomicWrite(treePath, this.manifestFileContent(manifest, content));
+          }
+        }
         await this.atomicWrite(
           this.refPath("active", sessionHash, checkpointId, phase),
           JSON.stringify({ treeId, ownerId: this.ownerId }),

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -311,6 +311,94 @@ describe("non-Git blob store", () => {
     await store.shutdown();
   });
 
+  it("excludes a blob store nested inside the workspace from snapshots", async () => {
+    const workspace = await temporaryDirectory("omp-blob-nested-workspace-");
+    const store = new BlobStore(join(workspace, "store"));
+    const session = sessionHash("nested-store");
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "tracked.txt"), "tracked");
+    await mkdir(join(workspace, "store", "inner"), { recursive: true });
+    await writeFile(join(workspace, "store", "inner", "sneaky.txt"), "sneaky");
+    await mkdir(join(workspace, "vendor", "data"), { recursive: true });
+    await writeFile(join(workspace, "vendor", "data", "decoy.txt"), "decoy");
+    const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in snapshot) throw new Error("snapshot failed");
+    expect(snapshot.entries.map((entry) => entry.path)).toEqual([
+      "tracked.txt",
+      "vendor/data/decoy.txt",
+    ]);
+    expect(snapshot.skippedPaths).toEqual([]);
+    expect(await store.treeUsable(snapshot.treeId)).toBe(true);
+    await store.shutdown();
+  });
+
+  it("captures an empty snapshot when the workspace root is the blob store root", async () => {
+    const workspace = await temporaryDirectory("omp-blob-degenerate-workspace-");
+    const store = new BlobStore(workspace);
+    const session = sessionHash("degenerate-root");
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "stray.txt"), "stray");
+    const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in snapshot) throw new Error("snapshot failed");
+    expect(snapshot.entries).toEqual([]);
+    expect(snapshot.skippedPaths).toEqual([]);
+    await store.shutdown();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "drops symlinks that resolve into the blob store",
+    async () => {
+      const workspace = await temporaryDirectory("omp-blob-symlink-store-workspace-");
+      const storage = await temporaryDirectory("omp-blob-symlink-store-storage-");
+      const store = new BlobStore(storage);
+      const session = sessionHash("symlink-store");
+      const checkpoint = randomUUID();
+      await writeFile(join(workspace, "tracked.txt"), "tracked");
+      await writeFile(join(storage, "payload.txt"), "payload");
+      await symlink(join(storage, "payload.txt"), join(workspace, "alias.txt"));
+      const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+      if ("reason" in snapshot) throw new Error("snapshot failed");
+      expect(snapshot.entries.map((entry) => entry.path)).toEqual(["tracked.txt"]);
+      expect(snapshot.skippedPaths).toEqual([]);
+      await store.shutdown();
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "records symlinks that resolve outside the blob store in skippedPaths",
+    async () => {
+      const workspace = await temporaryDirectory("omp-blob-symlink-outside-workspace-");
+      const storage = await temporaryDirectory("omp-blob-symlink-outside-storage-");
+      const outside = await temporaryDirectory("omp-blob-symlink-outside-target-");
+      const store = new BlobStore(storage);
+      const session = sessionHash("symlink-outside");
+      const checkpoint = randomUUID();
+      await writeFile(join(workspace, "tracked.txt"), "tracked");
+      await writeFile(join(outside, "target.txt"), "target");
+      await symlink(join(outside, "target.txt"), join(workspace, "alias.txt"));
+      const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+      if ("reason" in snapshot) throw new Error("snapshot failed");
+      expect(snapshot.entries.map((entry) => entry.path)).toEqual(["tracked.txt"]);
+      expect(snapshot.skippedPaths).toEqual(["alias.txt"]);
+      await store.shutdown();
+    },
+  );
+
+  it("honors the walk concurrency option", async () => {
+    const workspace = await temporaryDirectory("omp-blob-concurrency-workspace-");
+    const storage = await temporaryDirectory("omp-blob-concurrency-storage-");
+    const store = new BlobStore(storage, { walkConcurrency: 1 });
+    const session = sessionHash("concurrency-option");
+    const checkpoint = randomUUID();
+    await mkdir(join(workspace, "sub"));
+    await writeFile(join(workspace, "a.txt"), "a");
+    await writeFile(join(workspace, "sub", "b.txt"), "b");
+    const snapshot = await store.captureSnapshot(workspace, session, checkpoint, "before");
+    if ("reason" in snapshot) throw new Error("snapshot failed");
+    expect(snapshot.entries.map((entry) => entry.path)).toEqual(["a.txt", "sub/b.txt"]);
+    await store.shutdown();
+  });
+
   it("recovers an interrupted delete from its journal", async () => {
     const workspace = await temporaryDirectory("omp-blob-recovery-workspace-");
     const storage = await temporaryDirectory("omp-blob-recovery-storage-");


### PR DESCRIPTION
## Summary

Performance release v1.3.1 for the non-Git blob-store workspace walk.

- Drop per-entry \ealpath\ from walks; storage-root containment is now a normalized string-prefix comparison against canonical roots, with \ealpath\ retained only for symlink entries whose true target can diverge from the name path.
- Replace per-directory stat batches with a single global concurrency limit (\walkConcurrency\ option on \BlobStore\, default 16, capped 64), overlapping directory reads and file stats across the whole tree without depth multiplication.
- Skip the tree-manifest rewrite and its \exists\ probe when the captured tree ID matches the validated workspace cache; write the on-disk manifest from the already-hashed canonical string.
- Add \
pm run bench:walk\ (\scripts/bench-walk.mjs\) to measure cold, warm, and incremental captures on a synthetic workspace.
- New tests: nested-store exclusion, degenerate workspace==store root, symlink into/out of the store, walk-concurrency option.

Benchmark (100k files / 1000 dirs): warm capture 57.8s -> 4.9s, cold 438s -> 67s, incremental 3.5s.

## Verification

- npm run verify: formatting, eslint, typecheck, 131 tests passed, build parity, package smoke, pack check — all green.