### PR TITLE
perf: make store expiry lazy, gated, and incrementally sized (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.3.2] - 2026-08-13
+
+### Performance
+
+- Defer the store-wide expiration and garbage-collection sweep to a background run shortly after extension startup so session initialization and the first undo/redo no longer block on a scan of the entire shared store.
+- Skip the O(store) tree-manifest and blob sweep when nothing was actually expired or evicted; stale active-ref cleanup for crashed owners still runs on every pass.
+- Track blob store size incrementally (exact bytes for writes, deletion-adjusted after GC) so storage-cap eviction checks are O(1) instead of re-walking every blob and tree file per evicted session.
+
 ## [1.3.1] - 2026-08-13
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To disable either behavior, set its value to `0`; setting both to `0` disables a
 
 ### Expiration behavior
 
-Cleanup runs automatically at extension startup; nothing runs during active work, and sessions currently in use are never expired or evicted. Successful cleanup is silent. When a dormant session's file history is expired, resuming that session shows a warning: session navigation still works, but file changes from the expired turns cannot be restored, and `/undo`/`/redo` degrade to session-only navigation.
+Cleanup runs automatically in the background shortly after extension startup and never blocks session initialization or the first undo/redo; sessions currently in use are never expired or evicted. Successful cleanup is silent. When a dormant session's file history is expired, resuming that session shows a warning: session navigation still works, but file changes from the expired turns cannot be restored, and `/undo`/`/redo` degrade to session-only navigation.
 
 In Git workspaces, expiration removes the session's history refs under `refs/omp-undo-redo/history/<sessionHash>/` and its history file. The referenced commit objects become unreachable and are reclaimed later by the repository's normal `git gc`; `.git` size does not shrink immediately. No storage cap applies to Git object storage.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/blob-store.ts
+++ b/src/core/blob-store.ts
@@ -175,6 +175,16 @@ export class BlobStore {
   private leasePublished = false;
   private readonly workspaceCaches = new Map<string, WorkspaceCache>();
   private storageRoot: Promise<string> | null = null;
+  /** Exact on-disk bytes of blobs/ and trees/ at the last full scan (under the
+   *  store lock), or null when no scan has happened in this process. All blob
+   *  and tree mutations run under the store lock, so this stays exact as long
+   *  as every mutation is also reflected in pendingWriteSizes/pendingBytes.
+   *  Cross-process files written between this process's scan and a later GC
+   *  are not in either account, so their deletion drifts the estimate low by
+   *  at most one file's bytes — a bounded, self-healing approximation. */
+  private storeBytesAtLastScan: number | null = null;
+  private pendingBytes = 0;
+  private readonly pendingWriteSizes = new Map<string, number>();
 
   constructor(
     readonly rootDirectory: string,
@@ -307,6 +317,9 @@ export class BlobStore {
     });
   }
 
+  /** Writes a content-addressed blob if it does not already exist.
+   *  Must be called under withStoreLock — the size-tracking skip on
+   *  existence is mandatory to avoid double-counting in measureStoreBytes. */
   private async writeBlob(hash: string, content: Buffer): Promise<void> {
     const path = this.blobPath(hash);
     if (await exists(path)) return;
@@ -326,6 +339,34 @@ export class BlobStore {
       }
     } finally {
       await rm(temporary, { force: true }).catch(() => undefined);
+    }
+    this.trackStoreWrite(hash, content.length);
+  }
+
+  private trackStoreWrite(key: string, size: number): void {
+    const previous = this.pendingWriteSizes.get(key);
+    if (previous !== undefined) {
+      this.pendingBytes -= previous;
+    }
+    this.pendingWriteSizes.set(key, size);
+    this.pendingBytes += size;
+  }
+
+  /** Removes one file's bytes from the in-process store-size estimate. The key
+   *  distinguishes pending (written since the last scan) from scanned entries,
+   *  so the estimate stays exact without ever rescanning the store. */
+  private async untrackStoreFile(path: string, key: string): Promise<void> {
+    const pendingSize = this.pendingWriteSizes.get(key);
+    if (pendingSize !== undefined) {
+      this.pendingWriteSizes.delete(key);
+      this.pendingBytes -= pendingSize;
+      return;
+    }
+    if (this.storeBytesAtLastScan === null) return;
+    try {
+      this.storeBytesAtLastScan -= Math.min((await stat(path)).size, this.storeBytesAtLastScan);
+    } catch {
+      // The file is already gone; nothing to account for.
     }
   }
 
@@ -665,7 +706,9 @@ export class BlobStore {
           // present above and GC shares this lock, so no exists() check or rewrite
           // is needed.
           if (!(await exists(treePath))) {
-            await this.atomicWrite(treePath, this.manifestFileContent(manifest, content));
+            const manifestContent = this.manifestFileContent(manifest, content);
+            await this.atomicWrite(treePath, manifestContent);
+            this.trackStoreWrite(treeId, Buffer.byteLength(manifestContent));
           }
         }
         await this.atomicWrite(
@@ -1254,12 +1297,17 @@ export class BlobStore {
 
   async collectGarbage(): Promise<void> {
     await this.withStoreLock(async () => {
-      await this.collectGarbageUnlocked();
+      await this.collectGarbageUnlocked(true);
     });
   }
 
-  private async collectGarbageUnlocked(): Promise<void> {
+  private async collectGarbageUnlocked(sweep: boolean): Promise<void> {
     await this.cleanupStaleActiveRefs();
+    // The refs scan, manifest loads and blob/tree walks are O(entire store).
+    // Sweep only when session data was actually removed; stale-active-ref
+    // cleanup above still covers crashed owners. Orphans left by a crash
+    // mid-capture are reaped on the next real removal or by shutdown GC.
+    if (!sweep) return;
     const referencedTrees = new Set<string>();
     const scanRefs = async (directory: string): Promise<void> => {
       let children;
@@ -1287,8 +1335,11 @@ export class BlobStore {
       for (const child of await readdir(join(this.rootDirectory, "trees"))) {
         if (!child.endsWith(".json")) continue;
         const treeId = child.slice(0, -5);
-        if (!referencedTrees.has(treeId))
-          await rm(join(this.rootDirectory, "trees", child), { force: true });
+        if (!referencedTrees.has(treeId)) {
+          const path = join(this.rootDirectory, "trees", child);
+          await this.untrackStoreFile(path, treeId);
+          await rm(path, { force: true });
+        }
       }
     } catch {
       // Nothing to collect.
@@ -1298,7 +1349,11 @@ export class BlobStore {
         const directory = join(this.rootDirectory, "blobs", prefix);
         for (const child of await readdir(directory)) {
           const hash = `${prefix}${child}`;
-          if (!referencedBlobs.has(hash)) await rm(join(directory, child), { force: true });
+          if (!referencedBlobs.has(hash)) {
+            const path = join(directory, child);
+            await this.untrackStoreFile(path, hash);
+            await rm(path, { force: true });
+          }
         }
       }
     } catch {
@@ -1341,6 +1396,17 @@ export class BlobStore {
   }
 
   async measureStoreBytes(): Promise<number> {
+    if (this.storeBytesAtLastScan !== null) {
+      return this.storeBytesAtLastScan + this.pendingBytes;
+    }
+    const totalBytes = await this.scanStoreBytes();
+    this.storeBytesAtLastScan = totalBytes;
+    this.pendingBytes = 0;
+    this.pendingWriteSizes.clear();
+    return totalBytes;
+  }
+
+  private async scanStoreBytes(): Promise<number> {
     let totalBytes = 0;
     const scanDir = async (directory: string): Promise<void> => {
       let children;
@@ -1450,6 +1516,7 @@ export class BlobStore {
       };
 
       // Phase 1: Age-based expiration
+      let removedSomething = false;
       if (retentionDays > 0) {
         const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
         const files = await getHistoryFiles();
@@ -1460,6 +1527,7 @@ export class BlobStore {
             if (getActive().has(item.sessionHash)) continue;
             const refsDeleted = await removeSessionRefsInternal(item.sessionHash);
             if (!refsDeleted) continue;
+            removedSomething = true;
 
             const tombstoneFile = join(historyDir, `${item.sessionHash}.expired.json`);
             const tombstoneData = {
@@ -1490,11 +1558,13 @@ export class BlobStore {
 
           for (const item of items) {
             if (getActive().has(item.sessionHash)) continue;
-            currentBytes = await this.measureStoreBytes();
+            // After the first call above (which scans once), measureStoreBytes
+            // is O(1), so the per-iteration check no longer rescans the store.
             if (currentBytes <= maxStoreBytes) break;
 
             const refsDeleted = await removeSessionRefsInternal(item.sessionHash);
             if (!refsDeleted) continue;
+            removedSomething = true;
 
             const tombstoneFile = join(historyDir, `${item.sessionHash}.expired.json`);
             const tombstoneData = {
@@ -1507,13 +1577,15 @@ export class BlobStore {
               () => undefined,
             );
             await rm(item.filePath, { force: true }).catch(() => undefined);
-            await this.collectGarbageUnlocked();
+            await this.collectGarbageUnlocked(true);
+            currentBytes = await this.measureStoreBytes();
           }
         }
       }
 
-      // Always perform garbage collection and stale active-ref cleanup
-      await this.collectGarbageUnlocked();
+      // Garbage collection after removals, and stale active-ref cleanup always.
+      // The O(store) tree/blob sweep is skipped when nothing was removed.
+      await this.collectGarbageUnlocked(removedSomething);
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,12 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
   let pendingSwitchSourceSessionId: string | null = null;
   let pendingBranchSourceSessionId: string | null = null;
   const expirationPromises = new Map<string, Promise<void>>();
+  const expirationCancels = new Map<string, () => void>();
   const explicitActiveHashes = new Set<string>();
+  // Defer the background expiry sweep so the first capture of a fresh process
+  // (agent start or undo) wins the store lock instead of queueing behind a
+  // whole-store scan. The sweep still runs shortly after and always at close.
+  const EXPIRATION_GRACE_MS = 2_000;
 
   function activeSessionHashes(): ReadonlySet<string> {
     const hashes = new Set<string>();
@@ -204,15 +209,31 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     const store = new BlobStore(root);
     blobStores.set(root, store);
     const { retentionDays, maxStoreBytes } = retentionConfig;
-    if (retentionDays > 0 || maxStoreBytes > 0) {
-      const expiration = store
-        .expireAndCollect(retentionDays, maxStoreBytes, () => activeSessionHashes())
-        .catch(() => undefined);
-      expirationPromises.set(`blob:${root}`, expiration);
-    } else {
-      const gc = store.garbageCollect().catch(() => undefined);
-      expirationPromises.set(`blob:${root}`, gc);
-    }
+    const key = `blob:${root}`;
+    const operation =
+      retentionDays > 0 || maxStoreBytes > 0
+        ? () => store.expireAndCollect(retentionDays, maxStoreBytes, () => activeSessionHashes())
+        : () => store.garbageCollect();
+    let cancel: (() => void) | undefined;
+    const expiration = new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        expirationCancels.delete(key);
+        void operation()
+          .catch(() => undefined)
+          .then(resolve);
+      }, EXPIRATION_GRACE_MS);
+      timer.unref?.();
+      cancel = () => {
+        // No-op once the sweep has started; the promise then resolves when
+        // the sweep finishes, so shutdown still waits for the store lock.
+        if (!expirationCancels.has(key)) return;
+        clearTimeout(timer);
+        expirationCancels.delete(key);
+        resolve();
+      };
+    });
+    expirationCancels.set(key, cancel!);
+    expirationPromises.set(key, expiration);
     return store;
   }
 
@@ -249,16 +270,6 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
           () => activeSessionHashes(),
         ).catch(() => undefined);
         expirationPromises.set(`git:${backend.repository.commonDir}`, expiration);
-      }
-
-      const expirationKey =
-        backend.kind === "blob"
-          ? `blob:${blobStoreRootDirectory()}`
-          : backend.kind === "git"
-            ? `git:${backend.repository.commonDir}`
-            : undefined;
-      if (expirationKey) {
-        await expirationPromises.get(expirationKey);
       }
 
       const store =
@@ -600,8 +611,14 @@ export default function ompUndoRedo(pi: ExtensionAPI): void {
     navigations.clear();
     initializations.clear();
     pending.clear();
-    explicitActiveHashes.clear();
     shutdownPromise = (async () => {
+      // Let an in-flight expiry finish (it holds the store lock) and cancel one
+      // that never started, then stop protecting sessions so shutdown GC can
+      // reclaim their data.
+      for (const cancel of expirationCancels.values()) cancel();
+      expirationCancels.clear();
+      await Promise.allSettled([...expirationPromises.values()]);
+      explicitActiveHashes.clear();
       await disposeDetached(detachedNavigations, detachedPending, false);
       await Promise.allSettled([...activeOperations]);
       await drainState();

--- a/test/blob-expiration.test.ts
+++ b/test/blob-expiration.test.ts
@@ -473,6 +473,61 @@ describe("BlobStore expiration and storage cap", () => {
     await store.shutdown();
   });
 
+  it("skips the tree/blob sweep when nothing expired and sweeps on the next real removal", async () => {
+    const workspace = await temporaryDirectory("blob-exp-gate-ws-");
+    const storage = await temporaryDirectory("blob-exp-gate-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "gate-session";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+    await writeFile(join(workspace, "f.txt"), "gate content");
+    const snap = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    if ("reason" in snap) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const hStore = new BlobHistoryStore(sessionId, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: snap.treeId,
+          afterTreeId: snap.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    // Orphan a second capture by releasing its refs.
+    const orphanCheckpoint = randomUUID();
+    await writeFile(join(workspace, "orphan.txt"), "orphan");
+    const orphan = await store.captureSnapshot(workspace, hash, orphanCheckpoint, "before");
+    if ("reason" in orphan) throw new Error("snapshot failed");
+    await store.releaseCheckpointRefs(hash, [orphanCheckpoint]);
+    expect(await store.treeExists(orphan.treeId)).toBe(true);
+
+    // Nothing is expired (fresh history), so the O(store) sweep must be skipped.
+    await store.expireAndCollect(30, 0, new Set());
+    expect(await store.treeExists(orphan.treeId)).toBe(true);
+
+    // Aging the session makes expireAndCollect remove it; the sweep then
+    // reclaims the orphan that the no-op run left behind.
+    const hFile = join(storage, "history", `${hash}.json`);
+    const json = JSON.parse(await readFile(hFile, "utf8"));
+    json.lastAccessedAt = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(hFile, JSON.stringify(json));
+
+    await store.expireAndCollect(30, 0, new Set());
+    expect(await store.treeExists(orphan.treeId)).toBe(false);
+
+    await store.shutdown();
+  });
+
   it("uses dynamic activeSessionHashes getter to re-check candidate sessions at deletion time", async () => {
     const workspace = await temporaryDirectory("blob-exp-getter-ws-");
     const storage = await temporaryDirectory("blob-exp-getter-store-");

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -647,6 +647,53 @@ describe("non-Git blob store", () => {
     await store.shutdown();
   });
 
+  it("keeps the incremental store-size estimate exact across captures, GC, and eviction", async () => {
+    const workspace = await temporaryDirectory("omp-blob-measure-exact-workspace-");
+    const storage = await temporaryDirectory("omp-blob-measure-exact-storage-");
+    const store = new BlobStore(storage);
+
+    const onDiskBytes = async (): Promise<number> => {
+      let total = 0;
+      const scanDir = async (directory: string): Promise<void> => {
+        const children = await readdir(directory, { withFileTypes: true }).catch(() => []);
+        for (const child of children) {
+          const fullPath = join(directory, child.name);
+          if (child.isDirectory()) await scanDir(fullPath);
+          else total += (await stat(fullPath)).size;
+        }
+      };
+      await scanDir(join(storage, "blobs"));
+      await scanDir(join(storage, "trees"));
+      return total;
+    };
+
+    const checkpoint = randomUUID();
+    await writeFile(join(workspace, "kept.txt"), "kept content");
+    const kept = await store.captureSnapshot(workspace, sessionHash("kept"), checkpoint, "before");
+    if ("reason" in kept) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(sessionHash("kept"), checkpoint);
+
+    await writeFile(join(workspace, "orphan.txt"), "orphan content");
+    const orphanCheckpoint = randomUUID();
+    const orphan = await store.captureSnapshot(
+      workspace,
+      sessionHash("orphan"),
+      orphanCheckpoint,
+      "before",
+    );
+    if ("reason" in orphan) throw new Error("snapshot failed");
+    await store.releaseCheckpointRefs(sessionHash("orphan"), [orphanCheckpoint]);
+
+    expect(await store.measureStoreBytes()).toBe(await onDiskBytes());
+
+    await store.garbageCollect();
+    expect(await store.treeExists(kept.treeId)).toBe(true);
+    expect(await store.treeExists(orphan.treeId)).toBe(false);
+    expect(await store.measureStoreBytes()).toBe(await onDiskBytes());
+
+    await store.shutdown();
+  });
+
   it("releases all session refs", async () => {
     const workspace = await temporaryDirectory("omp-blob-release-workspace-");
     const storage = await temporaryDirectory("omp-blob-release-storage-");


### PR DESCRIPTION
## Summary

The store-wide expiration/GC sweep previously ran synchronously on the first session of each process and blocked session initialization (and the first undo/redo) behind an O(entire shared store) scan: every blob and tree file stat'd, every tree manifest re-hashed, unconditionally, even when nothing was expired.

## Changes

- **Defer the sweep (src/index.ts):** expiry runs in the background after a 2s grace period so the first capture wins the store lock; shutdown cancels a pending sweep, drains an in-flight one (it holds the store lock), and only then releases active-session protection.
- **Gate the O(store) sweep (src/core/blob-store.ts):** \collectGarbageUnlocked(sweep)\ only runs the tree/blob sweep when sessions were actually removed; stale active-ref cleanup still runs every pass.
- **Incremental store-size tracking (src/core/blob-store.ts):** \measureStoreBytes()\ is O(1) after one initial scan (exact pending bytes per blob/tree write, deletion-adjusted during GC), removing the per-eviction full store re-walk in the storage-cap loop.
- Bump to 1.3.2; CHANGELOG + README updated.

## Verification

- \
pm run verify\ passes: prettier, eslint, tsc, 133 tests (2 new regression tests for sweep gating and byte-accounting exactness), build, smoke, pack checks.