### PR TITLE
fix: restore multi-turn undo/redo cursor across restarts (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.4.1] - 2026-08-18
+
+### Fixed
+
+- Restore the undo/redo cursor on resume when the session was left at an undone turn or at a tree position browsed away from the cursor. Previously, resuming such a session silently discarded the whole durable file history and fell back to conversation-only undo. Completed Git and non-Git checkpoints plus the undo/redo cursor now survive a normal terminal restart in every multi-turn case, matching the README guarantee.
+- Treat the persisted history state as authoritative when all of its checkpoints still exist in the session tree, instead of re-deriving the cursor from the current tree leaf. Browsing the tree does not move the undo/redo cursor or the file state, so a leaf-based cursor guess conflicted with the workspace snapshot state.
+
+### Changed
+
+- Remove the now-unused leaf-matching load scan and the dead `expectedLeaf`/`matchesEffectiveLeaf` helpers from the history stores.
+
 ## [1.4.0] - 2026-08-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",
@@ -24,6 +24,11 @@
       },
       "peerDependencies": {
         "@oh-my-pi/pi-coding-agent": ">=16.5.2"
+      },
+      "peerDependenciesMeta": {
+        "@oh-my-pi/pi-coding-agent": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -5913,26 +5918,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/onnxruntime-node": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
-      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "peer": true,
-      "dependencies": {
-        "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.21.0",
-        "tar": "^7.0.1"
-      }
-    },
     "node_modules/onnxruntime-web": {
       "version": "1.26.0-dev.20260416-b7804b056c",
       "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
@@ -7224,6 +7209,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/blob-history-store.ts
+++ b/src/core/blob-history-store.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { blobStoreRootDirectory } from "./blob-store/index.js";
 import type { BlobStore } from "./blob-store/index.js";
 import { checkpointNamespace } from "./checkpoints.js";
-import { effectiveLeaf, entryExists, expectedLeaf } from "./session-tree-utils.js";
+import { effectiveLeaf, entryExists } from "./session-tree-utils.js";
 import type {
   BlobCheckpoint,
   ExpirationTombstone,
@@ -231,13 +231,15 @@ export class BlobHistoryStore {
           (checkpoint) =>
             !entryExists(reader, checkpoint.parentLeafId) ||
             !entryExists(reader, checkpoint.leafId),
-        ) ||
-        expectedLeaf(state) !== effectiveLeaf(reader)
+        )
       )
         return { status: "unavailable" };
 
-      await this.save(state).catch(() => undefined);
+      if (checkpoints.length === 0 && effectiveLeaf(reader) !== null) {
+        return { status: "unavailable" };
+      }
 
+      await this.save(state).catch(() => undefined);
       return { status: "loaded", state };
     } catch {
       return { status: "unavailable" };

--- a/src/core/history-store.ts
+++ b/src/core/history-store.ts
@@ -13,18 +13,8 @@ import type {
   SessionReader,
   TurnCheckpoint,
 } from "./types.js";
-import {
-  effectiveLeaf,
-  entryExists,
-  expectedLeaf,
-  isSessionExitEntry,
-} from "./session-tree-utils.js";
-export {
-  effectiveLeaf,
-  entryExists,
-  expectedLeaf,
-  isSessionExitEntry,
-} from "./session-tree-utils.js";
+import { effectiveLeaf, entryExists, isSessionExitEntry } from "./session-tree-utils.js";
+export { effectiveLeaf, entryExists, isSessionExitEntry } from "./session-tree-utils.js";
 
 const HISTORY_SCHEMA_CURRENT = 2;
 const ACCEPTED_SCHEMAS = new Set([1, 2]);
@@ -382,13 +372,15 @@ export class SessionHistoryStore {
           (checkpoint) =>
             !entryExists(reader, checkpoint.parentLeafId) ||
             !entryExists(reader, checkpoint.leafId),
-        ) ||
-        expectedLeaf(state) !== effectiveLeaf(reader)
+        )
       )
         return { status: "unavailable" };
 
-      await this.save(state).catch(() => undefined);
+      if (checkpoints.length === 0 && effectiveLeaf(reader) !== null) {
+        return { status: "unavailable" };
+      }
 
+      await this.save(state).catch(() => undefined);
       return { status: "loaded", state };
     } catch {
       return { status: "unavailable" };

--- a/src/core/session-tree-utils.ts
+++ b/src/core/session-tree-utils.ts
@@ -1,4 +1,4 @@
-import type { NavigationState, SessionEntryLike, SessionReader } from "./types.js";
+import type { SessionEntryLike, SessionReader } from "./types.js";
 
 export function entryExists(reader: SessionReader, id: string | null): boolean {
   return id === null || reader.getEntry(id) !== undefined;
@@ -18,11 +18,4 @@ export function effectiveLeaf(reader: SessionReader): string | null {
     leafId = entry?.parentId ?? null;
   }
   return leafId;
-}
-
-export function expectedLeaf(state: NavigationState): string | null {
-  if (state.checkpoints.length === 0) return null;
-  return state.currentIndex >= 0
-    ? state.checkpoints[state.currentIndex].leafId
-    : state.checkpoints[0].parentLeafId;
 }

--- a/test/blob-history-store.test.ts
+++ b/test/blob-history-store.test.ts
@@ -1,12 +1,22 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BlobHistoryStore } from "../src/core/blob-history-store.js";
 import { BlobStore } from "../src/core/blob-store/index.js";
 import { checkpointNamespace } from "../src/core/checkpoints.js";
-import type { BlobCheckpoint, SessionEntryLike, SessionReader } from "../src/core/types.js";
+import {
+  blobNavigationApplier,
+  blobNavigationReleaser,
+  SessionNavigation,
+} from "../src/core/session-navigation.js";
+import type {
+  BlobCheckpoint,
+  NavigationPort,
+  SessionEntryLike,
+  SessionReader,
+} from "../src/core/types.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -194,6 +204,234 @@ describe("blob history store", () => {
     await expect(history.load(reader())).resolves.toEqual({
       status: "expired",
       reason: "age",
+    });
+
+    await store.shutdown();
+  });
+
+  it("loads multi-turn state when active leaf is at an undone turn prompt boundary", async () => {
+    const workspace = await temporaryDirectory("omp-blob-multi-undo-workspace-");
+    const storage = await temporaryDirectory("omp-blob-multi-undo-storage-");
+    const sessionId = "multi-undo-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const store = new BlobStore(storage);
+
+    const c1Id = randomUUID();
+    const c2Id = randomUUID();
+
+    await writeFile(join(workspace, "file.txt"), "base");
+    const c1Before = await store.captureSnapshot(workspace, sessionHash, c1Id, "before");
+    await writeFile(join(workspace, "file.txt"), "turn1");
+    const c1After = await store.captureSnapshot(workspace, sessionHash, c1Id, "after");
+    await store.retainCheckpointForResume(sessionHash, c1Id);
+
+    const c2Before = await store.captureSnapshot(workspace, sessionHash, c2Id, "before");
+    await writeFile(join(workspace, "file.txt"), "turn2");
+    const c2After = await store.captureSnapshot(workspace, sessionHash, c2Id, "after");
+    await store.retainCheckpointForResume(sessionHash, c2Id);
+
+    if (
+      "reason" in c1Before ||
+      "reason" in c1After ||
+      "reason" in c2Before ||
+      "reason" in c2After
+    ) {
+      throw new Error("snapshot failed");
+    }
+
+    const c1: BlobCheckpoint = {
+      kind: "blob",
+      workspaceRoot: await realpath(workspace),
+      sessionHash,
+      checkpointId: c1Id,
+      beforeTreeId: c1Before.treeId,
+      afterTreeId: c1After.treeId,
+      parentLeafId: "p1",
+      leafId: "r1",
+    };
+    const c2: BlobCheckpoint = {
+      kind: "blob",
+      workspaceRoot: await realpath(workspace),
+      sessionHash,
+      checkpointId: c2Id,
+      beforeTreeId: c2Before.treeId,
+      afterTreeId: c2After.treeId,
+      parentLeafId: "p2",
+      leafId: "r2",
+    };
+
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    // State saved after undoing Turn 2 (currentIndex = 0, active leaf is p2)
+    await history.save({
+      checkpoints: [c1, c2],
+      currentIndex: 0,
+    });
+
+    const multiReader: SessionReader = {
+      getLeafId: () => "p2",
+      getBranch: () => [
+        { id: "p1", parentId: null, type: "message", message: { role: "user" } },
+        { id: "r1", parentId: "p1", type: "message", message: { role: "assistant" } },
+        { id: "p2", parentId: "r1", type: "message", message: { role: "user" } },
+      ],
+      getEntry: (id) => {
+        const all: SessionEntryLike[] = [
+          { id: "p1", parentId: null, type: "message", message: { role: "user" } },
+          { id: "r1", parentId: "p1", type: "message", message: { role: "assistant" } },
+          { id: "p2", parentId: "r1", type: "message", message: { role: "user" } },
+          { id: "r2", parentId: "p2", type: "message", message: { role: "assistant" } },
+        ];
+        return all.find((e) => e.id === id);
+      },
+    };
+
+    const loaded = await history.load(multiReader);
+    expect(loaded).toEqual({
+      status: "loaded",
+      state: {
+        checkpoints: [c1, c2],
+        currentIndex: 0,
+      },
+    });
+
+    await store.shutdown();
+  });
+
+  it("keeps the persisted cursor and full chain when resuming at a checkpoint browsed backward past the cursor", async () => {
+    const workspace = await temporaryDirectory("omp-blob-browse-back-workspace-");
+    const storage = await temporaryDirectory("omp-blob-browse-back-storage-");
+    const sessionId = "browse-back-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const store = new BlobStore(storage);
+
+    const entries: SessionEntryLike[] = [
+      { id: "p1", parentId: null, type: "message", message: { role: "user" } },
+      { id: "r1", parentId: "p1", type: "message", message: { role: "assistant" } },
+      { id: "p2", parentId: "r1", type: "message", message: { role: "user" } },
+      { id: "r2", parentId: "p2", type: "message", message: { role: "assistant" } },
+      { id: "p3", parentId: "r2", type: "message", message: { role: "user" } },
+      { id: "r3", parentId: "p3", type: "message", message: { role: "assistant" } },
+    ];
+
+    const checkpoints: BlobCheckpoint[] = [];
+    const turnFiles = ["base", "turn1", "turn2", "turn3"];
+    for (let turn = 1; turn <= 3; turn++) {
+      const checkpointId = randomUUID();
+      await writeFile(join(workspace, "file.txt"), turnFiles[turn - 1]);
+      const before = await store.captureSnapshot(workspace, sessionHash, checkpointId, "before");
+      await writeFile(join(workspace, "file.txt"), turnFiles[turn]);
+      const after = await store.captureSnapshot(workspace, sessionHash, checkpointId, "after");
+      if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+      await store.retainCheckpointForResume(sessionHash, checkpointId);
+      checkpoints.push({
+        kind: "blob",
+        workspaceRoot: await realpath(workspace),
+        sessionHash,
+        checkpointId,
+        beforeTreeId: before.treeId,
+        afterTreeId: after.treeId,
+        parentLeafId: `p${turn}`,
+        leafId: `r${turn}`,
+      });
+    }
+
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    // State saved after completing all three turns at r3 (currentIndex = 2).
+    // The user then browsed the tree back to p1 without touching files, so
+    // the workspace still holds the turn-3 content at shutdown.
+    await history.save({ checkpoints, currentIndex: 2 });
+
+    const resumed: NavigationPort = {
+      leaf: "p1",
+      getLeafId() {
+        return resumed.leaf;
+      },
+      getEntry: (id) => entries.find((entry) => entry.id === id),
+      getBranch: () => entries,
+      async navigateTree(targetId) {
+        resumed.leaf = targetId;
+        return { cancelled: false };
+      },
+    };
+
+    // Browsing does not move the cursor or the file state, so the persisted
+    // cursor must survive the resume untouched.
+    const loaded = await history.load(resumed);
+    expect(loaded).toEqual({
+      status: "loaded",
+      state: { checkpoints, currentIndex: 2 },
+    });
+
+    const navigation = new SessionNavigation(
+      resumed,
+      async () => ({ stdout: "", stderr: "", code: 0 }),
+      undefined,
+      undefined,
+      blobNavigationApplier(store),
+      blobNavigationReleaser(store),
+    );
+    navigation.restoreState(loaded.state);
+
+    for (let turn = 3; turn >= 1; turn--) {
+      expect((await navigation.undo()).status).toBe("moved");
+      expect(resumed.leaf).toBe(`p${turn}`);
+      expect(await readFile(join(workspace, "file.txt"), "utf8")).toBe(turnFiles[turn - 1]);
+    }
+    expect((await navigation.undo()).status).toBe("empty");
+
+    for (let turn = 1; turn <= 3; turn++) {
+      expect((await navigation.redo()).status).toBe("moved");
+      expect(resumed.leaf).toBe(`r${turn}`);
+      expect(await readFile(join(workspace, "file.txt"), "utf8")).toBe(turnFiles[turn]);
+    }
+    expect((await navigation.redo()).status).toBe("empty");
+
+    await store.shutdown();
+  });
+
+  it("loads persisted history when the active leaf is not on the checkpoint chain", async () => {
+    const workspace = await temporaryDirectory("omp-blob-off-chain-workspace-");
+    const storage = await temporaryDirectory("omp-blob-off-chain-storage-");
+    const sessionId = "off-chain-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const store = new BlobStore(storage);
+
+    const c1Id = randomUUID();
+    await writeFile(join(workspace, "file.txt"), "base");
+    const c1Before = await store.captureSnapshot(workspace, sessionHash, c1Id, "before");
+    await writeFile(join(workspace, "file.txt"), "turn1");
+    const c1After = await store.captureSnapshot(workspace, sessionHash, c1Id, "after");
+    if ("reason" in c1Before || "reason" in c1After) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(sessionHash, c1Id);
+    const c1: BlobCheckpoint = {
+      kind: "blob",
+      workspaceRoot: await realpath(workspace),
+      sessionHash,
+      checkpointId: c1Id,
+      beforeTreeId: c1Before.treeId,
+      afterTreeId: c1After.treeId,
+      parentLeafId: "p1",
+      leafId: "r1",
+    };
+
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    await history.save({ checkpoints: [c1], currentIndex: 0 });
+
+    const chainEntries: SessionEntryLike[] = [
+      { id: "p1", parentId: null, type: "message", message: { role: "user" } },
+      { id: "r1", parentId: "p1", type: "message", message: { role: "assistant" } },
+      { id: "p2", parentId: "r1", type: "message", message: { role: "user" } },
+      { id: "r2", parentId: "p2", type: "message", message: { role: "assistant" } },
+    ];
+    const offChainReader: SessionReader = {
+      getLeafId: () => "r2",
+      getBranch: () => chainEntries,
+      getEntry: (id) => chainEntries.find((entry) => entry.id === id),
+    };
+
+    expect(await history.load(offChainReader)).toEqual({
+      status: "loaded",
+      state: { checkpoints: [c1], currentIndex: 0 },
     });
 
     await store.shutdown();

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -1123,4 +1123,99 @@ describe("history-safe Git checkpoints", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("loads multi-turn Git session history when active leaf is at undone prompt boundary", async () => {
+    const { cwd, git } = await makeRepo();
+    const repository = {
+      worktree: cwd,
+      gitDir: join(cwd, ".git"),
+      commonDir: join(cwd, ".git"),
+    };
+    const sessionId = "chk-multi-undo-session";
+    const sessionHash = checkpointNamespace(sessionId);
+
+    const p1: SessionEntryLike = {
+      id: "p1",
+      parentId: null,
+      type: "message",
+      message: { role: "user" },
+    };
+    const r1: SessionEntryLike = {
+      id: "r1",
+      parentId: "p1",
+      type: "message",
+      message: { role: "assistant" },
+    };
+    const p2: SessionEntryLike = {
+      id: "p2",
+      parentId: "r1",
+      type: "message",
+      message: { role: "user" },
+    };
+    const r2: SessionEntryLike = {
+      id: "r2",
+      parentId: "p2",
+      type: "message",
+      message: { role: "assistant" },
+    };
+
+    try {
+      await initializeBranch(git, cwd);
+      const { SessionHistoryStore } = await import("../src/core/history-store.js");
+      const store = new SessionHistoryStore(sessionId, repository, git);
+
+      // Create valid refs for two checkpoints
+      const head = (await git(["rev-parse", "HEAD"])).stdout.trim();
+      const refPrefix = `refs/omp-undo-redo/history/${sessionHash}/`;
+      await git(["update-ref", `${refPrefix}c1/before`, head]);
+      await git(["update-ref", `${refPrefix}c1/after`, head]);
+      await git(["update-ref", `${refPrefix}c2/before`, head]);
+      await git(["update-ref", `${refPrefix}c2/after`, head]);
+
+      const c1: TurnCheckpoint = {
+        kind: "git",
+        repository,
+        beforeRef: `${refPrefix}c1/before`,
+        beforeHash: head,
+        afterRef: `${refPrefix}c1/after`,
+        afterHash: head,
+        parentLeafId: "p1",
+        leafId: "r1",
+      };
+      const c2: TurnCheckpoint = {
+        kind: "git",
+        repository,
+        beforeRef: `${refPrefix}c2/before`,
+        beforeHash: head,
+        afterRef: `${refPrefix}c2/after`,
+        afterHash: head,
+        parentLeafId: "p2",
+        leafId: "r2",
+      };
+
+      // State saved after undoing Turn 2 (currentIndex = 0, sitting at p2)
+      await store.save({
+        checkpoints: [c1, c2],
+        currentIndex: 0,
+      });
+
+      // Reader is sitting at p2 (undone prompt)
+      const multiReader: SessionReader = {
+        getLeafId: () => "p2",
+        getBranch: () => [p1, r1, p2],
+        getEntry: (id) => [p1, r1, p2, r2].find((e) => e.id === id),
+      };
+
+      const loaded = await store.load(multiReader);
+      expect(loaded).toEqual({
+        status: "loaded",
+        state: {
+          checkpoints: [c1, c2],
+          currentIndex: 0,
+        },
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -562,6 +562,118 @@ describe("resumed session history", () => {
     }
   });
 
+  it("restores multi-turn undo and redo checkpoints across runtime restarts when undone turns exist", async () => {
+    const cwd = await makeRepository();
+    const sessionId = "resumed-multi-turn-session";
+    const p1: TestEntry = {
+      id: "p1",
+      parentId: null,
+      type: "message",
+      message: { role: "user" },
+    };
+    const r1: TestEntry = {
+      id: "r1",
+      parentId: p1.id,
+      type: "message",
+      message: { role: "assistant" },
+    };
+    const p2: TestEntry = {
+      id: "p2",
+      parentId: r1.id,
+      type: "message",
+      message: { role: "user" },
+    };
+    const r2: TestEntry = {
+      id: "r2",
+      parentId: p2.id,
+      type: "message",
+      message: { role: "assistant" },
+    };
+    try {
+      const firstApi = new FakeExtensionApi();
+      ompUndoRedo(firstApi as never);
+      const first = context(cwd, sessionId);
+      first.leaf = p1.id;
+      first.branch = [p1];
+      first.entries = [p1];
+      await firstApi.emit("session_start", first);
+
+      // Turn 1
+      await firstApi.emit("before_agent_start", first);
+      await writeFile(join(cwd, "tracked.txt"), "turn1\n");
+      first.leaf = r1.id;
+      first.branch = [p1, r1];
+      first.entries = [p1, r1];
+      await firstApi.emit("agent_end", first);
+
+      // Turn 2
+      first.leaf = p2.id;
+      first.branch = [p1, r1, p2];
+      first.entries = [p1, r1, p2];
+      await firstApi.emit("before_agent_start", first);
+      await writeFile(join(cwd, "tracked.txt"), "turn2\n");
+      first.leaf = r2.id;
+      first.branch = [p1, r1, p2, r2];
+      first.entries = [p1, r1, p2, r2];
+      await firstApi.emit("agent_end", first);
+
+      // Undo turn 2 before shutdown
+      first.navigateTree = async (targetId) => {
+        first.leaf = targetId;
+        first.branch = targetId === p2.id ? [p1, r1, p2] : [p1];
+        return { cancelled: false };
+      };
+      await firstApi.runCommand("undo", first);
+      expect(first.leaf).toBe(p2.id);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("turn1\n");
+      await firstApi.emit("session_shutdown", first);
+
+      // Resume in a fresh extension process at leaf p2
+      const secondApi = new FakeExtensionApi();
+      ompUndoRedo(secondApi as never);
+      const second = context(cwd, sessionId);
+      second.leaf = p2.id;
+      second.branch = [p1, r1, p2];
+      second.entries = [p1, r1, p2, r2];
+      second.navigateTree = async (targetId) => {
+        second.leaf = targetId;
+        if (targetId === r2.id) second.branch = [p1, r1, p2, r2];
+        else if (targetId === p2.id) second.branch = [p1, r1, p2];
+        else if (targetId === p1.id) second.branch = [p1];
+        return { cancelled: false };
+      };
+      await secondApi.emit("session_start", second);
+
+      // Redo turn 2
+      await secondApi.runCommand("redo", second);
+      expect(second.leaf).toBe(r2.id);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("turn2\n");
+      expect(second.ui.notifications.at(-1)?.message).toBe(
+        "Redid last turn: session moved forward and file snapshot restored.",
+      );
+
+      // Undo turn 2 again
+      await secondApi.runCommand("undo", second);
+      expect(second.leaf).toBe(p2.id);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("turn1\n");
+      expect(second.ui.notifications.at(-1)?.message).toBe(
+        "Undid last turn: session moved back and file snapshot restored.",
+      );
+
+      // Undo turn 1
+      await secondApi.runCommand("undo", second);
+      expect(second.leaf).toBe(p1.id);
+      expect(await readFile(join(cwd, "tracked.txt"), "utf8")).toBe("base\n");
+      expect(second.ui.notifications.at(-1)?.message).toBe(
+        "Undid last turn: session moved back and file snapshot restored.",
+      );
+
+      await secondApi.emit("session_shutdown", second);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("reconstructs conversation-only undo when no durable file history exists", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omp-undo-redo-resumed-session-only-"));
     const prompt: TestEntry = {


### PR DESCRIPTION
## Summary

Fixes the README guarantee violation: resuming a session after undoing turns (or after browsing the tree away from the cursor) silently discarded the durable file history and fell back to conversation-only undo.

Root cause: \load()\ required the current tree leaf to equal the persisted cursor position (\expectedLeaf\), and the attempted fix then re-derived the cursor from the leaf. But browsing does not move the cursor or the file state, so a leaf-derived guess conflicted with the workspace snapshots (redo/undo would fail with blob/git conflicts) and truncated valid redo chains.

Fix: the persisted state is authoritative when all its checkpoints still exist in the session tree (\entryExists\ guard). The leaf-matching scan and the \expectedLeaf\/\matchesEffectiveLeaf\ helpers are removed.

## Changes
- \src/core/history-store.ts\, \src/core/blob-history-store.ts\: load the persisted cursor as-is; keep the empty-checkpoint guard
- \src/core/session-tree-utils.ts\: remove dead \expectedLeaf\/\matchesEffectiveLeaf\
- Tests: prompt-boundary resume (git + blob), browse-back resume with full undo/redo chain walk, off-chain leaf load, lifecycle multi-turn undo/redo across restarts

## Verification
- \
pm run verify\ passed (format, lint, typecheck, 139 tests, build, smoke, pack)
- Version 1.4.1 not yet on npm