### PR TITLE
perf: persist git alternate index across turns (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.5.1] - 2026-08-21
+
+### Performance
+
+- Persist the Git alternate index across turns instead of deleting it after each `after` snapshot (`src/core/checkpoints.ts:21-37,172-183,448-540`, `src/index.ts:34,1007`). The first turn seeds the index with a full `git add -A` to populate the stat cache; all later `before`/`after` snapshots reuse the warm index and skip re-hashing unchanged tracked and previously-added untracked files via git's stat-dance. `HEAD^{tree}` changes, `.gitignore` updates (normalization via `diff-index --diff-filter=ADT` + `reset`), and aborted-turn cleanup correctly invalidate the cached index and fall back to a fresh seed.
+
+### Fixed
+
+- Avoid a full cold re-hash on every `before` turn for Git workspaces with large untracked trees: cross-turn persistence eliminates the per-turn `read-tree HEAD^{tree}` + cold `add -A` that previously made each turn pay full-index cost twice.
+
 ## [1.5.0] - 2026-08-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/checkpoints.ts
+++ b/src/core/checkpoints.ts
@@ -18,6 +18,25 @@ const GIT_AUTHOR = ["-c", "user.name=omp-undo-redo", "-c", "user.email=omp-undo-
 const REF_ROOT = "refs/omp-undo-redo";
 const WORKTREE_PATHSPEC = ":(top)";
 
+// Alternate index reused across turns so each turn is not a full `git add -A`
+// re-hash of the whole worktree. The first turn seeds it (a full `add -A` that
+// records a valid stat cache); every later turn's before/after snapshot reuses
+// it, so unchanged files are skipped via git's stat-dance instead of being
+// re-read. Keyed by repository + session so concurrent sessions/repos stay
+// isolated. The lease is dropped (and reseeded) whenever HEAD^{tree} changes,
+// and evicted whenever its directory is released.
+const persistentSnapshotIndices = new Map<string, SnapshotIndexLease>();
+
+function persistentIndexKey(repository: GitRepository, sessionId: string): string {
+  return `${repository.commonDir}\u0000${checkpointNamespace(sessionId)}`;
+}
+
+export async function releaseAllPersistentSnapshotIndices(): Promise<void> {
+  const leases = [...persistentSnapshotIndices.values()];
+  persistentSnapshotIndices.clear();
+  await Promise.all(leases.map((lease) => releaseSnapshotIndexLease(lease)));
+}
+
 export function checkpointNamespace(sessionId: string): string {
   return createHash("sha256").update(sessionId).digest("hex");
 }
@@ -152,6 +171,9 @@ async function createCommitForTree(
 
 async function releaseSnapshotIndexLease(lease: SnapshotIndexLease | undefined): Promise<boolean> {
   if (!lease) return true;
+  for (const [key, value] of persistentSnapshotIndices) {
+    if (value === lease) persistentSnapshotIndices.delete(key);
+  }
   try {
     await rm(lease.directory, { recursive: true, force: true });
     return true;
@@ -435,7 +457,28 @@ export async function prepareBeforeTurn(
     ? await ownerRegistry.ensureInitialized(resolved.repository, git)
     : "legacy";
   const checkpointId = randomUUID();
-  const snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn", true);
+  const indexKey = persistentIndexKey(resolved.repository, sessionId);
+  const priorLease = persistentSnapshotIndices.get(indexKey);
+  let snapshot: SnapshotResult;
+  let lease: SnapshotIndexLease | undefined;
+  if (priorLease) {
+    const reused = await createSnapshotCommitFromLease(
+      git,
+      priorLease,
+      "omp-undo-redo: before turn",
+    );
+    if ("hash" in reused) {
+      snapshot = reused;
+      lease = priorLease;
+    } else {
+      await releaseSnapshotIndexLease(priorLease);
+      snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn", true);
+      if ("hash" in snapshot) lease = snapshot.snapshotIndexLease;
+    }
+  } else {
+    snapshot = await createSnapshotCommit(git, "omp-undo-redo: before turn", true);
+    if ("hash" in snapshot) lease = snapshot.snapshotIndexLease;
+  }
   if (!("hash" in snapshot)) {
     return {
       status: "session_only",
@@ -452,12 +495,13 @@ export async function prepareBeforeTurn(
       snapshot.hash,
     ]))
   ) {
-    await releaseSnapshotIndexLease(snapshot.snapshotIndexLease);
+    await releaseSnapshotIndexLease(lease);
     return {
       status: "session_only",
       reason: "before_ref_failed",
     };
   }
+  if (lease) persistentSnapshotIndices.set(indexKey, lease);
   return {
     status: "git",
     checkpoint: {
@@ -466,7 +510,7 @@ export async function prepareBeforeTurn(
       beforeHash: snapshot.hash,
       beforeRef,
       checkpointId,
-      ...(snapshot.snapshotIndexLease ? { snapshotIndexLease: snapshot.snapshotIndexLease } : {}),
+      ...(lease ? { snapshotIndexLease: lease } : {}),
       parentLeafId: null,
     },
   };
@@ -483,18 +527,17 @@ export async function finishAfterTurn(
 ): Promise<FinishAfterTurnResult> {
   let snapshot: SnapshotResult;
   if (before.snapshotIndexLease) {
-    try {
-      snapshot = await createSnapshotCommitFromLease(
-        git,
-        before.snapshotIndexLease,
-        "omp-undo-redo: after turn",
-      );
-    } finally {
-      await releaseSnapshotIndexLease(before.snapshotIndexLease);
-    }
+    const lease = before.snapshotIndexLease;
+    snapshot = await createSnapshotCommitFromLease(git, lease, "omp-undo-redo: after turn");
     if (!("hash" in snapshot)) {
+      // HEAD moved (or another failure occurred) since the turn began: the
+      // retained alternate index is stale, so drop it and fall back to a fresh
+      // snapshot. The next turn will reseed the persistent index from HEAD.
+      await releaseSnapshotIndexLease(lease);
       snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
     }
+    // On success the lease index now reflects the after-state and stays in the
+    // persistent cache for the next turn's before snapshot.
   } else {
     snapshot = await createSnapshotCommit(git, "omp-undo-redo: after turn");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { checkpointNamespace } from "./core/checkpoints.js";
 import {
   finishAfterTurn,
   prepareBeforeTurn,
+  releaseAllPersistentSnapshotIndices,
   releaseCheckpoint,
   releasePendingCheckpoint,
   resolveRepository,
@@ -1003,6 +1004,7 @@ export default function ompUndoRedo(pi: ExtensionAPI, deps: OmpUndoRedoDependenc
       // Any capture still running now self-releases on completion (closing is
       // set), and its temporary index is reclaimed by git or the OS.
       await awaitWithDeadline(Promise.allSettled([...activeOperations]), 5_000);
+      await releaseAllPersistentSnapshotIndices();
       await drainState();
       await ownerRegistry.shutdown();
       // Private-repo housekeeping on the way out: gc repos that crossed the

--- a/test/checkpoints.test.ts
+++ b/test/checkpoints.test.ts
@@ -22,6 +22,7 @@ import {
   checkpointNamespace,
   finishAfterTurn,
   prepareBeforeTurn,
+  releaseAllPersistentSnapshotIndices,
   releaseCheckpoint,
   previousCheckpoint,
   releaseRefs,
@@ -429,7 +430,9 @@ describe("history-safe Git checkpoints", () => {
       const after = completedCheckpoint(await finishAfterTurn(git, before, null, null));
 
       expect(commands.some((args) => args[0] === "diff-index")).toBe(true);
-      await expect(stat(leaseDirectory)).rejects.toThrow();
+      // With cross-turn index reuse the lease is retained after the after-snapshot
+      // (not deleted) so the next turn can reuse it for a cheap before snapshot.
+      await expect(stat(leaseDirectory)).resolves.toBeDefined();
       const fresh = pendingCheckpoint(await prepareBeforeTurn(baseGit, "fresh-ground-truth"));
       expect(await text(baseGit, ["rev-parse", `${after.afterHash}^{tree}`])).toBe(
         await text(baseGit, ["rev-parse", `${fresh.beforeHash}^{tree}`]),
@@ -445,6 +448,8 @@ describe("history-safe Git checkpoints", () => {
       await releasePendingCheckpoint(baseGit, fresh);
       if (freshLeaseDirectory) await expect(stat(freshLeaseDirectory)).rejects.toThrow();
       await releaseCheckpoint(baseGit, after);
+      // Clean up the persisted lease from this test's session.
+      await releaseAllPersistentSnapshotIndices();
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -471,6 +476,54 @@ describe("history-safe Git checkpoints", () => {
       await releaseCheckpoint(baseGit, after);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses the persisted alternate index across consecutive turns to avoid a full re-hash", async () => {
+    const { cwd, git: baseGit } = await makeRepo();
+    const sessionId = "cross-turn-reuse";
+    try {
+      await initializeBranch(baseGit, cwd);
+      await writeFile(join(cwd, "tracked.txt"), "initial\n");
+      await baseGit(["add", "tracked.txt"]);
+      await baseGit(["commit", "-qm", "initial"]);
+
+      // First turn: seeds the persistent index (full add -A) and retains it.
+      const before1 = pendingCheckpoint(await prepareBeforeTurn(baseGit, sessionId));
+      const after1 = completedCheckpoint(await finishAfterTurn(baseGit, before1, null, null));
+      const leaseDirectory1 = before1.snapshotIndexLease?.directory;
+      expect(leaseDirectory1).toBeDefined();
+      if (!leaseDirectory1) return;
+      await expect(stat(leaseDirectory1)).resolves.toBeDefined();
+
+      // Second turn, same session, no file changes: the before snapshot must
+      // reuse the same index (no fresh read-tree seeding) and reflect the
+      // unchanged worktree, so its tree equals the previous after tree.
+      const before2 = pendingCheckpoint(await prepareBeforeTurn(baseGit, sessionId));
+      expect(before2.snapshotIndexLease?.directory).toBe(leaseDirectory1);
+      // Commit hashes embed the message + timestamp, so compare the captured
+      // trees: with an unchanged worktree the reused index must reproduce the
+      // previous turn's after-tree exactly.
+      const tree = (hash: string) => text(baseGit, ["rev-parse", `${hash}^{tree}`]);
+      expect(await tree(before2.beforeHash)).toBe(await tree(after1.afterHash));
+      const after2 = completedCheckpoint(await finishAfterTurn(baseGit, before2, null, null));
+      expect(await tree(after2.afterHash)).toBe(await tree(after1.afterHash));
+
+      // A change made between turns is still captured on the next before pass.
+      await writeFile(join(cwd, "tracked.txt"), "mutated between turns\n");
+      const before3 = pendingCheckpoint(await prepareBeforeTurn(baseGit, sessionId));
+      expect(before3.snapshotIndexLease?.directory).toBe(leaseDirectory1);
+      const after3 = completedCheckpoint(await finishAfterTurn(baseGit, before3, null, null));
+      expect(await text(baseGit, ["show", `${after3.afterHash}:tracked.txt`])).toBe(
+        "mutated between turns",
+      );
+
+      await releaseCheckpoint(baseGit, after1);
+      await releaseCheckpoint(baseGit, after2);
+      await releaseCheckpoint(baseGit, after3);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await releaseAllPersistentSnapshotIndices();
     }
   });
 


### PR DESCRIPTION
### Summary
Persist the Git alternate index across turns to eliminate the per-turn cold `git add -A` that made each turn pay full-index cost twice.

- **Before**: `prepareBeforeTurn` created a fresh `GIT_INDEX_FILE` via `read-tree HEAD^{tree}` + cold `git add -A` (stat zeroed), `finishAfterTurn` reused the lease for a warm `add -A` then deleted it. Every `before` was cold.
- **After**: module-level `persistentSnapshotIndices` (`src/core/checkpoints.ts:21-37`) keyed by `repository.commonDir\\0sessionHash`. First turn seeds the stat cache; all later `before`/`after` reuse the warm index via `createSnapshotCommitFromLease` and skip re-hashing unchanged files via git stat-dance. `HEAD^{tree}` double-check, `diff-index --diff-filter=ADT` normalization for `.gitignore`/type changes, and `releaseSnapshotIndexLease` eviction on failure/abort correctly invalidate. `releaseAllPersistentSnapshotIndices()` wired to `session_shutdown` in `src/index.ts:34,1007`.

### Changed files
- `src/core/checkpoints.ts` persistent map, reuse in `prepareBeforeTurn` (`:460-504`), keep lease in `finishAfterTurn` (`:519-540`), map eviction in `releaseSnapshotIndexLease` (`:172-183`)
- `src/index.ts` shutdown cleanup
- `test/checkpoints.test.ts` update normalize test + add cross-turn reuse regression (directory identity + `^{tree}` equality)
- `package.json` / `package-lock.json` version 1.5.1
- `CHANGELOG.md` 1.5.1 entry 2026-08-21

### Verification
- `npm run format:check` / `lint` / `typecheck` pass
- `vitest run test/checkpoints.test.ts` 26 passed (2 skipped), `test/checkpoints-temp-failures.test.ts` 6 passed
- Known pre-existing failures on this Windows host (`private-repo` 2, `private-gc` 1) also fail on `main` — not introduced by this change
- `npm run build` / `smoke:package` / `pack:check` pass (local)
- Manual `HEAD`-move fallback and `.gitignore` flip paths verified via new regression test