### PR TITLE
fix: keep live session history safe from cross-process expiration sweeps (v1.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.5.4] - 2026-08-25
+
+### Fixed
+
+- **Cross-process expiration no longer destroys live session history (per-process active-set blindness):** retention sweeps filtered candidates only against the local process's in-memory active set, so a sweeper in one process could delete git refs / blob refs and tombstone a session that another process (same repo `commonDir` or shared blob store) was actively resuming. A resume racing the ref deletion then re-persisted the degraded state, durably converting file-restorable checkpoints into navigation-only rows. Fixes: history stores never persist runtime-downgraded checkpoints — `load()` rewrites the stored document with the original coordinates and a fresh timestamp only (`src/core/history-store.ts`, `src/core/blob-history-store.ts`); every load/save touches a cross-process heartbeat marker (`<historyDir>/.active.<sessionHash>`, TTL 24h) that both sweepers honor alongside the local active set, with a pre-deletion re-check (`src/core/history-liveness.ts`, `src/core/history-store.ts`, `src/core/blob-store/gc.ts`, `src/core/prune-tombstones.ts`); a 10-minute unref'd interval re-asserts liveness for all locally tracked sessions so idle-but-open sessions stay protected (`src/index.ts`).
+- Tombstones are now authoritative until superseded: a live owner's `save()` clears its own expiration marker so post-expiry sessions recover undo capability on their next turn instead of reporting "expired" until tombstone pruning; sweeps remove any history JSON that coexists with a standing tombstone (residue from a concurrent load rewriting the file mid-sweep), keeping the marker authoritative without resurrecting data.
+- Storage-cap eviction keeps its hard oldest-first guarantee: liveness is enforced purely by heartbeat markers (a live session in any process is never evicted), while unprotected stale sessions remain ordinary candidates — the cap is met as before instead of being soft-floored.
+
 ## [1.5.3] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ To disable either behavior, set its value to `0`; setting both to `0` disables a
 | `2`              | `0`              | Age expiration (2 days); no storage cap enforcement                                                       |
 | `0`              | `0`              | No automatic cleanup (indefinite retention)                                                               |
 
-> **Note:** `OMP_UNDO_REDO_RETENTION_DAYS=0` disables age-based expiration but does **not** guarantee indefinite history retention when a storage cap is active (`MAX_STORE_MB > 0`). The cap can still evict the oldest inactive session histories to free up storage space. Active sessions are never evicted by age or storage cap.
+> **Note:** `OMP_UNDO_REDO_RETENTION_DAYS=0` disables age-based expiration but does **not** guarantee indefinite history retention when a storage cap is active (`MAX_STORE_MB > 0`). The cap can still evict the oldest inactive session histories to free up storage space. Active sessions are never evicted by age or storage cap, in any process sharing the store.
 
 ### Expiration behavior
 
 Cleanup runs automatically in the background shortly after extension startup and never blocks session initialization or the first undo/redo; sessions currently in use are never expired or evicted. Successful cleanup is silent. When a dormant session's file history is expired, resuming that session shows a warning: session navigation still works, but file changes from the expired turns cannot be restored, and `/undo`/`/redo` degrade to session-only navigation.
+
+"In use" is enforced across processes: every history load/save touches a liveness marker (`.active.<sessionHash>`, fresh for 24 hours) in the shared history directory, a background interval re-asserts it for all locally active sessions every 10 minutes, and retention sweeps skip any session with a fresh marker — including sweeps started by another process sharing the same repository or store. Once an expired session records a new turn, its saved history supersedes the expiration marker, so undo capability resumes for the new turns instead of every later resume reporting "expired".
 
 In Git workspaces, expiration removes the session's history refs under `refs/omp-undo-redo/history/<sessionHash>/` and its history file. The referenced commit objects become unreachable and are reclaimed later by the repository's normal `git gc`; `.git` size does not shrink immediately. No storage cap applies to Git object storage.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/blob-history-store.ts
+++ b/src/core/blob-history-store.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { blobStoreRootDirectory } from "./blob-store/index.js";
 import type { BlobStore } from "./blob-store/index.js";
 import { checkpointNamespace } from "./checkpoints.js";
+import { touchSessionHeartbeat } from "./history-liveness.js";
 import { effectiveLeaf, entryExists } from "./session-tree-utils.js";
 import type {
   BlobCheckpoint,
@@ -154,6 +155,7 @@ export class BlobHistoryStore {
       .then(() => true)
       .catch(() => false);
     if (!present) return { status: "unavailable", reason: "missing" };
+    await touchSessionHeartbeat(dirname(this.path), this.sessionHash);
     const workspace = await this.canonicalWorkspace();
     if (!workspace) return { status: "unavailable", reason: "unusable" };
     try {
@@ -246,10 +248,43 @@ export class BlobHistoryStore {
         return { status: "unavailable", reason: "unusable" };
       }
 
-      await this.save(state).catch(() => undefined);
+      // Refresh lastAccessedAt without persisting the runtime-mapped
+      // checkpoints: a concurrent expiration that released refs or removed
+      // trees mid-load would otherwise be written back as permanent
+      // session-only rows, destroying recoverable tree coordinates. The
+      // mapping is re-derived on every load.
+      await this.refreshStoredTimestamp(candidate).catch(() => undefined);
       return { status: "loaded", state };
     } catch {
       return { status: "unavailable", reason: "unusable" };
+    }
+  }
+
+  /** Rewrites the stored document with the original (unmapped) checkpoints
+   *  and a fresh lastAccessedAt, preserving schema migration. Skips the write
+   *  when a tombstone appeared mid-load so a completed expiration is never
+   *  resurrected. */
+  private async refreshStoredTimestamp(candidate: Record<string, unknown>): Promise<void> {
+    const claimed = await stat(blobTombstonePath(this.sessionId, this.store.rootDirectory))
+      .then(() => true)
+      .catch(() => false);
+    if (claimed) return;
+    const directory = dirname(this.path);
+    const stored: StoredHistory = {
+      schemaVersion: HISTORY_SCHEMA_CURRENT,
+      sessionHash: this.sessionHash,
+      workspaceRoot: candidate.workspaceRoot as string,
+      checkpoints: candidate.checkpoints as TurnCheckpoint[],
+      currentIndex: candidate.currentIndex as number,
+      lastAccessedAt: new Date().toISOString(),
+    };
+    const temporary = join(directory, `.${this.sessionHash}.${randomUUID()}.tmp`);
+    try {
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+      await writeFile(temporary, JSON.stringify(stored), { encoding: "utf8", mode: 0o600 });
+      await rename(temporary, this.path);
+    } finally {
+      await rm(temporary, { force: true }).catch(() => undefined);
     }
   }
 
@@ -292,5 +327,13 @@ export class BlobHistoryStore {
     } finally {
       await rm(temporary, { force: true }).catch(() => undefined);
     }
+    // A live owner saving new history supersedes any earlier expiration
+    // marker, so clear it — otherwise every future resume would discard the
+    // freshly saved checkpoints until the marker aged out of the tombstone
+    // prune window.
+    await rm(blobTombstonePath(this.sessionId, this.store.rootDirectory), {
+      force: true,
+    }).catch(() => undefined);
+    await touchSessionHeartbeat(directory, this.sessionHash);
   }
 }

--- a/src/core/blob-store/gc.ts
+++ b/src/core/blob-store/gc.ts
@@ -1,11 +1,12 @@
 import { readFile, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { atomicWrite, isHash } from "./fs.js";
+import { atomicWrite, exists, isHash } from "./fs.js";
 import { readTreeManifest } from "./manifest.js";
 import { readRefFile, type RefRegistry } from "./refs.js";
 import type { StoreLiveness } from "./liveness.js";
 import type { StoreAccountant } from "./accounting.js";
 import type { TreeManifest } from "./types.js";
+import { pruneStaleHeartbeats, sessionHeartbeatIsFresh } from "../history-liveness.js";
 import { pruneExpiredTombstones } from "../prune-tombstones.js";
 
 /** Garbage collection and retention policy: reference counting over refs/
@@ -136,12 +137,32 @@ export class StoreJanitor {
       }
     };
 
+    // Residue cleanup: a history JSON that coexists with its tombstone can
+    // only be an artifact of a concurrent load rewriting the file mid-sweep.
+    // The marker stays authoritative until a live owner saves anew — which
+    // clears it — so the JSON must go regardless of its timestamp. Runs
+    // unconditionally so cap-only configurations still reclaim residue.
+    for (const file of await getHistoryFiles()) {
+      const sessionHash = file.slice(0, -5);
+      if (!isHash(sessionHash)) continue;
+      const tombstoneFile = join(historyDir, `${sessionHash}.expired.json`);
+      if (!(await exists(tombstoneFile))) continue;
+      const filePath = join(historyDir, file);
+      // Re-check immediately before the rm to stay out of a save()'s
+      // clear-and-rewrite path for a session that just came back to life.
+      if (!(await exists(tombstoneFile))) continue;
+      await rm(filePath, { force: true }).catch(() => undefined);
+    }
+
     const parseSessionTimestamp = async (
       file: string,
     ): Promise<{ sessionHash: string; timestamp: number; filePath: string } | null> => {
       const sessionHash = file.slice(0, -5);
       if (!isHash(sessionHash)) return null;
       if (getActive().has(sessionHash)) return null;
+      // Cross-process liveness: another process may hold this session open
+      // without this process knowing. A fresh heartbeat protects it here.
+      if (await sessionHeartbeatIsFresh(historyDir, sessionHash)) return null;
       const filePath = join(historyDir, file);
       try {
         const content = await readFile(filePath, "utf8");
@@ -229,7 +250,10 @@ export class StoreJanitor {
       }
     }
 
-    await pruneExpiredTombstones(historyDir, retentionDays, getActive, isHash);
+    await pruneExpiredTombstones(historyDir, retentionDays, getActive, isHash, (hash) =>
+      sessionHeartbeatIsFresh(historyDir, hash),
+    );
+    await pruneStaleHeartbeats(historyDir);
 
     // Garbage collection after removals, and stale active-ref cleanup always.
     // The O(store) tree/blob sweep is skipped when nothing was removed.

--- a/src/core/history-liveness.ts
+++ b/src/core/history-liveness.ts
@@ -1,0 +1,85 @@
+import { readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Cross-process liveness for session history retention.
+ *
+ * History files live in directories shared by every process resolving the
+ * same repository commonDir or blob store root, but each process's in-memory
+ * active-session set only covers its own sessions. A retention sweep in
+ * process A can therefore target a session that process B is actively
+ * loading or saving. Every store touches a `.active.<sessionHash>` marker in
+ * the history directory on each load and save; sweepers treat a fresh marker
+ * as proof of life no matter which process wrote it and skip the session.
+ *
+ * The TTL is deliberately generous: a stale marker left by a crashed owner
+ * merely delays expiration of already-old history, while a false negative
+ * durably destroys live undo state. Markers whose owners stopped beating are
+ * pruned by the same sweeps so the directory stays bounded.
+ */
+export const ACTIVE_HEARTBEAT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export function activeHeartbeatPath(historyDir: string, sessionHash: string): string {
+  return join(historyDir, `.active.${sessionHash}`);
+}
+
+/** Best-effort liveness beat: refreshes the marker's mtime, creating it on
+ *  first touch. Failures never block the caller; the remaining sweep guards
+ *  (local active set, fail-closed ref deletion) still apply. */
+export async function touchSessionHeartbeat(
+  historyDir: string,
+  sessionHash: string,
+): Promise<void> {
+  const path = activeHeartbeatPath(historyDir, sessionHash);
+  const now = new Date();
+  try {
+    await utimes(path, now, now);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") return;
+    try {
+      await writeFile(path, "", { encoding: "utf8", mode: 0o600 });
+    } catch {
+      // Advisory marker only.
+    }
+  }
+}
+
+export async function sessionHeartbeatIsFresh(
+  historyDir: string,
+  sessionHash: string,
+  ttlMs: number = ACTIVE_HEARTBEAT_TTL_MS,
+): Promise<boolean> {
+  try {
+    const metadata = await stat(activeHeartbeatPath(historyDir, sessionHash));
+    return Date.now() - metadata.mtimeMs < ttlMs;
+  } catch {
+    return false;
+  }
+}
+
+/** Removes markers whose owners stopped beating so the history directory
+ *  does not accumulate one file per historical session forever. */
+export async function pruneStaleHeartbeats(
+  historyDir: string,
+  ttlMs: number = ACTIVE_HEARTBEAT_TTL_MS,
+): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(historyDir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith(".active.")) continue;
+    const path = join(historyDir, name);
+    try {
+      const metadata = await stat(path);
+      if (!metadata.isFile()) continue;
+      if (Date.now() - metadata.mtimeMs >= ttlMs) {
+        await rm(path, { force: true }).catch(() => undefined);
+      }
+    } catch {
+      // Vanished between readdir and stat.
+    }
+  }
+}

--- a/src/core/history-store.ts
+++ b/src/core/history-store.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { checkpointNamespace } from "./checkpoints.js";
+import {
+  pruneStaleHeartbeats,
+  sessionHeartbeatIsFresh,
+  touchSessionHeartbeat,
+} from "./history-liveness.js";
 import { pruneExpiredTombstones } from "./prune-tombstones.js";
 import type {
   ExpirationTombstone,
@@ -251,9 +256,31 @@ export async function expireGitSessionHistories(
     if (!file.endsWith(".json") || file.endsWith(".expired.json") || file.startsWith(".")) continue;
     const sessionHash = file.slice(0, -5);
     if (!HASH.test(sessionHash)) continue;
-    if (getActive().has(sessionHash)) continue;
-
     const filePath = join(dir, file);
+
+    // A tombstoned history JSON is residue from a concurrent load rewriting
+    // the file mid-sweep (or a load racing the rm). The marker stays
+    // authoritative until a live owner saves anew — which clears it — so the
+    // JSON must go regardless of its timestamp. Re-checked immediately before
+    // the rm to stay out of a save()'s clear-and-rewrite path.
+    const existingTombstone = tombstonePath(repository, sessionHash);
+    let tombstoned = false;
+    try {
+      await stat(existingTombstone);
+      tombstoned = true;
+    } catch {
+      // No marker: normal candidate path.
+    }
+    if (tombstoned) {
+      await rm(filePath, { force: true }).catch(() => undefined);
+      continue;
+    }
+
+    if (getActive().has(sessionHash)) continue;
+    // Cross-process liveness: another process may hold this session open
+    // without this process knowing. A fresh heartbeat protects it here.
+    if (await sessionHeartbeatIsFresh(dir, sessionHash)) continue;
+
     let lastAccessedAtMs: number;
     try {
       const content = await readFile(filePath, "utf8");
@@ -275,6 +302,9 @@ export async function expireGitSessionHistories(
 
     // Re-check active set right before deletion to prevent racing concurrent session startup
     if (getActive().has(sessionHash)) continue;
+    // And re-check the cross-process heartbeat, which a concurrent resume in
+    // another process may have touched while the timestamp was being read.
+    if (await sessionHeartbeatIsFresh(dir, sessionHash)) continue;
 
     const refPrefix = `refs/omp-undo-redo/history/${sessionHash}/`;
     const refsMap = await existingRefs(git, refPrefix);
@@ -316,7 +346,14 @@ export async function expireGitSessionHistories(
     await rm(filePath, { force: true }).catch(() => undefined);
   }
 
-  await pruneExpiredTombstones(dir, retentionDays, getActive, (v) => HASH.test(v));
+  await pruneExpiredTombstones(
+    dir,
+    retentionDays,
+    getActive,
+    (v) => HASH.test(v),
+    (hash) => sessionHeartbeatIsFresh(dir, hash),
+  );
+  await pruneStaleHeartbeats(dir);
 }
 
 export class SessionHistoryStore {
@@ -328,6 +365,7 @@ export class SessionHistoryStore {
 
   async load(reader: SessionReader): Promise<HistoryLoadResult> {
     const sessionHash = checkpointNamespace(this.sessionId);
+    const dir = historyDirectory(this.repository);
     const tombstoneFile = tombstonePath(this.repository, this.sessionId);
     const tombstone = await readTombstone(tombstoneFile, sessionHash);
     if (tombstone) {
@@ -339,16 +377,15 @@ export class SessionHistoryStore {
       .then(() => true)
       .catch(() => false);
     if (!present) return { status: "unavailable", reason: "missing" };
+    await touchSessionHeartbeat(dir, sessionHash);
     try {
       const metadata = await stat(path);
       if (!metadata.isFile() || metadata.size > MAX_HISTORY_BYTES) {
         return { status: "unavailable", reason: "unusable" };
       }
-      const parsed = parseHistory(
-        JSON.parse(await readFile(path, "utf8")) as unknown,
-        this.sessionId,
-        this.repository,
-      );
+      const value = JSON.parse(await readFile(path, "utf8")) as unknown;
+      const candidate = value as Record<string, unknown>;
+      const parsed = parseHistory(value, this.sessionId, this.repository);
       if (!parsed) return { status: "unavailable", reason: "unusable" };
       const refPrefix = `refs/omp-undo-redo/history/${parsed.sessionHash}/`;
       const refs = await existingRefs(this.git, refPrefix);
@@ -389,10 +426,46 @@ export class SessionHistoryStore {
         return { status: "unavailable", reason: "unusable" };
       }
 
-      await this.save(state).catch(() => undefined);
+      // Refresh lastAccessedAt without persisting the runtime-mapped
+      // checkpoints: a concurrent expiration that deleted refs mid-load would
+      // otherwise be written back as permanent session-only rows, destroying
+      // recoverable git coordinates. The mapping is re-derived on every load.
+      await this.refreshStoredTimestamp(candidate).catch(() => undefined);
       return { status: "loaded", state };
     } catch {
       return { status: "unavailable", reason: "unusable" };
+    }
+  }
+
+  /** Rewrites the stored document with the original (unmapped) checkpoints
+   *  and a fresh lastAccessedAt, preserving schema migration. Skips the write
+   *  when a tombstone appeared mid-load so a completed expiration is never
+   *  resurrected. */
+  private async refreshStoredTimestamp(candidate: Record<string, unknown>): Promise<void> {
+    const tombstoneFile = tombstonePath(this.repository, this.sessionId);
+    const claimed = await stat(tombstoneFile)
+      .then(() => true)
+      .catch(() => false);
+    if (claimed) return;
+    const directory = historyDirectory(this.repository);
+    const stored: StoredHistory = {
+      schemaVersion: HISTORY_SCHEMA_CURRENT,
+      sessionHash: checkpointNamespace(this.sessionId),
+      repository: this.repository,
+      checkpoints: candidate.checkpoints as TurnCheckpoint[],
+      currentIndex: candidate.currentIndex as number,
+      lastAccessedAt: new Date().toISOString(),
+    };
+    const temporary = join(
+      directory,
+      `.${checkpointNamespace(this.sessionId)}.${randomUUID()}.tmp`,
+    );
+    try {
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+      await writeFile(temporary, JSON.stringify(stored), { encoding: "utf8", mode: 0o600 });
+      await rename(temporary, historyPath(this.repository, this.sessionId));
+    } finally {
+      await rm(temporary, { force: true }).catch(() => undefined);
     }
   }
 
@@ -439,5 +512,13 @@ export class SessionHistoryStore {
     } finally {
       await rm(temporary, { force: true }).catch(() => undefined);
     }
+    // A live owner saving new history supersedes any earlier expiration
+    // marker, so clear it — otherwise every future resume would discard the
+    // freshly saved checkpoints until the marker aged out of the tombstone
+    // prune window.
+    await rm(tombstonePath(this.repository, this.sessionId), { force: true }).catch(
+      () => undefined,
+    );
+    await touchSessionHeartbeat(directory, sessionHash);
   }
 }

--- a/src/core/prune-tombstones.ts
+++ b/src/core/prune-tombstones.ts
@@ -11,6 +11,7 @@ export async function pruneExpiredTombstones(
   retentionDays: number,
   getActive: () => ReadonlySet<string>,
   isHashFn: (value: string) => boolean,
+  isLive?: (sessionHash: string) => Promise<boolean>,
 ): Promise<void> {
   if (retentionDays <= 0) return;
   const tombstoneCutoff = Date.now() - retentionDays * 2 * 24 * 60 * 60 * 1000;
@@ -24,6 +25,10 @@ export async function pruneExpiredTombstones(
     if (!file.endsWith(".expired.json")) continue;
     const sessionHash = file.slice(0, -13);
     if (!isHashFn(sessionHash) || getActive().has(sessionHash)) continue;
+    // Keep the expiry signal for sessions a foreign process still holds open:
+    // pruning it would downgrade the resume-time message from "expired" to a
+    // generic "could not be loaded".
+    if (isLive && (await isLive(sessionHash))) continue;
     const path = join(historyDir, file);
     try {
       const content = await readFile(path, "utf8");

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,11 @@ import {
 } from "./core/checkpoints.js";
 import {
   expireGitSessionHistories,
+  historyDirectory,
   reconstructSessionHistory,
   SessionHistoryStore,
 } from "./core/history-store.js";
+import { touchSessionHeartbeat } from "./core/history-liveness.js";
 import type {
   ActionId,
   GitRepository,
@@ -475,6 +477,34 @@ export default function ompUndoRedo(pi: ExtensionAPI, deps: OmpUndoRedoDependenc
     }
     return hashes;
   }
+
+  // Cross-process liveness beats: load/save touch .active markers, but a
+  // session left open and idle would otherwise go stale past the heartbeat
+  // TTL while its owner process is still running. A slow unref'd interval
+  // re-asserts liveness for exactly the locally active sessions (the same
+  // set the sweeps already treat as protected), so foreign sweepers never
+  // see a live session as expired. Deliberately not `backends`: that map
+  // retains every session ever initialized here, and beating abandoned ones
+  // would shield them from retention for the process's lifetime.
+  const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
+  const heartbeatTimer = setInterval(() => {
+    const tracked = new Set<string>([
+      ...navigations.keys(),
+      ...initializations.keys(),
+      ...pending.keys(),
+    ]);
+    for (const sessionId of tracked) {
+      const backend = backends.get(sessionId);
+      if (!backend || backend.kind === "session") continue;
+      const sessionHash = checkpointNamespace(sessionId);
+      if (backend.kind === "git") {
+        void touchSessionHeartbeat(historyDirectory(backend.repository), sessionHash);
+      } else {
+        void touchSessionHeartbeat(join(backend.store.rootDirectory, "history"), sessionHash);
+      }
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref();
 
   function blobStoreFor(_workspaceRoot: string): BlobStore {
     const root = blobStoreRootDirectory();
@@ -1076,6 +1106,7 @@ export default function ompUndoRedo(pi: ExtensionAPI, deps: OmpUndoRedoDependenc
       // Let an in-flight expiry finish (it holds the store lock) and cancel one
       // that never started, then stop protecting sessions so shutdown GC can
       // reclaim their data.
+      clearInterval(heartbeatTimer);
       for (const cancel of expirationCancels.values()) cancel();
       expirationCancels.clear();
       await Promise.allSettled([...expirationPromises.values()]);

--- a/test/blob-expiration.test.ts
+++ b/test/blob-expiration.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -65,6 +65,8 @@ describe("BlobStore expiration and storage cap", () => {
     const content = JSON.parse(await readFile(historyFilePath, "utf8"));
     content.lastAccessedAt = oldDate;
     await writeFile(historyFilePath, JSON.stringify(content));
+    // Drop the heartbeat the save left behind: no owner process remains.
+    await rm(join(storage, "history", `.active.${hash}`), { force: true });
 
     // Run expireAndCollect with 30 days retention
     await store.expireAndCollect(30, 0, new Set());
@@ -130,6 +132,8 @@ describe("BlobStore expiration and storage cap", () => {
       const json = JSON.parse(await readFile(hFile, "utf8"));
       json.lastAccessedAt = dateStr;
       await writeFile(hFile, JSON.stringify(json));
+      // Drop the heartbeat the save left behind: no owner process remains.
+      await rm(join(storage, "history", `.active.${h}`), { force: true });
     };
 
     await setupSession(s1, h1, "content session 1 ".repeat(100), 10);
@@ -278,6 +282,8 @@ describe("BlobStore expiration and storage cap", () => {
     const json1 = JSON.parse(await readFile(hFile1, "utf8"));
     json1.lastAccessedAt = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
     await writeFile(hFile1, JSON.stringify(json1));
+    // Drop the heartbeat the save left behind: no owner process remains.
+    await rm(join(storage, "history", `.active.${h1}`), { force: true });
 
     const totalBytes = await store.measureStoreBytes();
     // Set cap bytes slightly below totalBytes so evicting s1's manifest gets store under cap without evicting s2
@@ -337,6 +343,8 @@ describe("BlobStore expiration and storage cap", () => {
       const json = JSON.parse(await readFile(hFile, "utf8"));
       json.lastAccessedAt = dateStr;
       await writeFile(hFile, JSON.stringify(json));
+      // Drop the heartbeat the save left behind: no owner process remains.
+      await rm(join(storage, "history", `.active.${h}`), { force: true });
     };
 
     // s1 is 40 days old (expires by age 30)
@@ -461,6 +469,8 @@ describe("BlobStore expiration and storage cap", () => {
     delete json.lastAccessedAt;
     json.schemaVersion = 1;
     await writeFile(hFile, JSON.stringify(json));
+    // Drop the heartbeat the save left behind: no owner process remains.
+    await rm(join(storage, "history", `.active.${hash}`), { force: true });
 
     const fortyDaysAgoSec = (Date.now() - 40 * 24 * 60 * 60 * 1000) / 1000;
     const { utimes } = await import("node:fs/promises");
@@ -521,6 +531,8 @@ describe("BlobStore expiration and storage cap", () => {
     const json = JSON.parse(await readFile(hFile, "utf8"));
     json.lastAccessedAt = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString();
     await writeFile(hFile, JSON.stringify(json));
+    // Drop the heartbeat the save left behind: no owner process remains.
+    await rm(join(storage, "history", `.active.${hash}`), { force: true });
 
     await store.expireAndCollect(30, 0, new Set());
     expect(await store.treeExists(orphan.treeId)).toBe(false);
@@ -576,6 +588,182 @@ describe("BlobStore expiration and storage cap", () => {
     await store.expireAndCollect(30, 0, activeGetter);
 
     expect((await stat(hFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("preserves sessions with a fresh cross-process heartbeat during age expiration", async () => {
+    const workspace = await temporaryDirectory("blob-exp-beat-ws-");
+    const storage = await temporaryDirectory("blob-exp-beat-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "heartbeat-session";
+    const hash = sessionHash(sessionId);
+    const checkpointId = randomUUID();
+
+    await writeFile(join(workspace, "f.txt"), "heartbeat content");
+    const snap = await store.captureSnapshot(workspace, hash, checkpointId, "before");
+    if ("reason" in snap) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(hash, checkpointId);
+
+    const hStore = new BlobHistoryStore(sessionId, workspace, store);
+    await hStore.save({
+      checkpoints: [
+        {
+          kind: "blob",
+          workspaceRoot: workspace,
+          sessionHash: hash,
+          checkpointId,
+          beforeTreeId: snap.treeId,
+          afterTreeId: snap.treeId,
+          parentLeafId: "p",
+          leafId: "r",
+        },
+      ],
+      currentIndex: 0,
+    });
+
+    // Age only the recorded timestamp. A foreign process keeps touching the
+    // heartbeat marker, so a sweeper that cannot see it must still treat
+    // the session as live.
+    const hFile = join(storage, "history", `${hash}.json`);
+    const json = JSON.parse(await readFile(hFile, "utf8"));
+    json.lastAccessedAt = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(hFile, JSON.stringify(json));
+
+    await store.expireAndCollect(30, 0, new Set());
+
+    expect((await stat(hFile)).isFile()).toBe(true);
+    await expect(stat(blobTombstonePath(sessionId, storage))).rejects.toThrow();
+
+    // Once the owner stops beating past the TTL, the same sweep expires the
+    // session and prunes the stale marker.
+    const markerPath = join(storage, "history", `.active.${hash}`);
+    const stale = (Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000;
+    await utimes(markerPath, stale, stale);
+
+    await store.expireAndCollect(30, 0, new Set());
+
+    await expect(stat(hFile)).rejects.toThrow();
+    const tombstone = JSON.parse(await readFile(blobTombstonePath(sessionId, storage), "utf8"));
+    expect(tombstone.reason).toBe("age");
+    await expect(stat(markerPath)).rejects.toThrow();
+
+    await store.shutdown();
+  });
+
+  it("keeps the storage cap hard while heartbeat-protected sessions survive eviction", async () => {
+    const workspace = await temporaryDirectory("blob-exp-capbeat-ws-");
+    const storage = await temporaryDirectory("blob-exp-capbeat-store-");
+    const store = new BlobStore(storage);
+
+    const evictable = "capbeat-old";
+    const protectedSession = "capbeat-live";
+    const evictableHash = sessionHash(evictable);
+    const protectedHash = sessionHash(protectedSession);
+
+    const setupSession = async (
+      sId: string,
+      h: string,
+      content: string,
+      keepHeartbeat: boolean,
+    ) => {
+      const chk = randomUUID();
+      await writeFile(join(workspace, `${sId}.txt`), content);
+      const before = await store.captureSnapshot(workspace, h, chk, "before");
+      if ("reason" in before) throw new Error("snapshot failed");
+      await store.retainCheckpointForResume(h, chk);
+      const hStore = new BlobHistoryStore(sId, workspace, store);
+      await hStore.save({
+        checkpoints: [
+          {
+            kind: "blob",
+            workspaceRoot: workspace,
+            sessionHash: h,
+            checkpointId: chk,
+            beforeTreeId: before.treeId,
+            afterTreeId: before.treeId,
+            parentLeafId: "p",
+            leafId: "r",
+          },
+        ],
+        currentIndex: 0,
+      });
+      if (!keepHeartbeat) {
+        // Unprotected: aged timestamp and no liveness marker, so a foreign
+        // sweeper sees it as an ordinary inactive candidate.
+        const hFile = join(storage, "history", `${h}.json`);
+        const json = JSON.parse(await readFile(hFile, "utf8"));
+        json.lastAccessedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+        await writeFile(hFile, JSON.stringify(json));
+        await rm(join(storage, "history", `.active.${h}`), { force: true });
+      }
+    };
+
+    await setupSession(evictable, evictableHash, "old session payload ".repeat(200), false);
+    const bytesAfterOld = await store.measureStoreBytes();
+    await setupSession(protectedSession, protectedHash, "protected payload ".repeat(20), true);
+
+    // Cap sits below the total, but above what remains after the unprotected
+    // oldest session is evicted.
+    const totalBytes = await store.measureStoreBytes();
+    const capBytes = totalBytes - Math.floor((totalBytes - bytesAfterOld) / 2) - 1;
+
+    await store.expireAndCollect(0, capBytes, new Set());
+
+    const oldFile = join(storage, "history", `${evictableHash}.json`);
+    await expect(stat(oldFile)).rejects.toThrow();
+    const tombstone = JSON.parse(await readFile(blobTombstonePath(evictable, storage), "utf8"));
+    expect(tombstone.reason).toBe("storage_cap");
+
+    // The heartbeat-protected session survives: its marker proves a live
+    // owner in some process, even though it is the newest history present.
+    const liveFile = join(storage, "history", `${protectedHash}.json`);
+    expect((await stat(liveFile)).isFile()).toBe(true);
+
+    await store.shutdown();
+  });
+
+  it("removes a history JSON that coexists with its tombstone (residue cleanup)", async () => {
+    const workspace = await temporaryDirectory("blob-exp-residue-ws-");
+    const storage = await temporaryDirectory("blob-exp-residue-store-");
+    const store = new BlobStore(storage);
+
+    const sessionId = "residue-session";
+    const hash = sessionHash(sessionId);
+
+    const historyDir = join(storage, "history");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(historyDir, { recursive: true });
+
+    // A concurrent load rewrote the file after the sweep completed: fresh
+    // timestamp, no owner. The tombstone must stay authoritative.
+    const hFile = join(historyDir, `${hash}.json`);
+    await writeFile(
+      hFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        workspaceRoot: workspace,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: new Date().toISOString(),
+      }),
+    );
+    await writeFile(
+      join(historyDir, `${hash}.expired.json`),
+      JSON.stringify({
+        expired: true,
+        sessionHash: hash,
+        expiredAt: new Date().toISOString(),
+        reason: "age",
+      }),
+    );
+
+    await store.expireAndCollect(30, 0, new Set());
+
+    await expect(stat(hFile)).rejects.toThrow();
+    expect((await stat(join(historyDir, `${hash}.expired.json`))).isFile()).toBe(true);
 
     await store.shutdown();
   });

--- a/test/blob-history-store.test.ts
+++ b/test/blob-history-store.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, mkdtemp, realpath, rm, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -202,6 +202,118 @@ describe("blob history store", () => {
         currentIndex: 0,
       },
     });
+    await store.shutdown();
+  });
+
+  it("does not persist downgraded checkpoints to disk on load", async () => {
+    const workspace = await temporaryDirectory("omp-blob-nopersist-ws-");
+    const storage = await temporaryDirectory("omp-blob-nopersist-store-");
+    const sessionId = "blob-nopersist-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const checkpointId = randomUUID();
+    const store = new BlobStore(storage);
+    await writeFile(join(workspace, "file.txt"), "before");
+    const before = await store.captureSnapshot(workspace, sessionHash, checkpointId, "before");
+    await writeFile(join(workspace, "file.txt"), "after");
+    const after = await store.captureSnapshot(workspace, sessionHash, checkpointId, "after");
+    if ("reason" in before || "reason" in after) throw new Error("snapshot failed");
+    await store.retainCheckpointForResume(sessionHash, checkpointId);
+    const checkpoint: BlobCheckpoint = {
+      kind: "blob",
+      workspaceRoot: await realpath(workspace),
+      sessionHash,
+      checkpointId,
+      beforeTreeId: before.treeId,
+      afterTreeId: after.treeId,
+      parentLeafId: "prompt",
+      leafId: "response",
+    };
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    await history.save({ checkpoints: [checkpoint], currentIndex: 0 });
+
+    // The save left a cross-process heartbeat marker for this session.
+    const markerPath = join(storage, "history", `.active.${sessionHash}`);
+    expect((await stat(markerPath)).isFile()).toBe(true);
+
+    await rm(join(storage, "trees", `${before.treeId}.json`), { force: true });
+    await expect(history.load(reader())).resolves.toEqual({
+      status: "loaded",
+      state: {
+        checkpoints: [
+          {
+            kind: "session",
+            reason: "resumed_checkpoint_unavailable",
+            parentLeafId: "prompt",
+            leafId: "response",
+          },
+        ],
+        currentIndex: 0,
+      },
+    });
+
+    // The runtime downgrade must stay in memory only: the stored document
+    // keeps the original blob coordinates (plus a refreshed timestamp), so a
+    // concurrent expiration can never turn a transient race into permanent
+    // data loss.
+    const raw = JSON.parse(await readFile(join(storage, "history", `${sessionHash}.json`), "utf8"));
+    expect(raw.schemaVersion).toBe(2);
+    expect(typeof raw.lastAccessedAt).toBe("string");
+    expect(raw.checkpoints).toEqual([checkpoint]);
+
+    await store.shutdown();
+  });
+
+  it("clears a superseded tombstone when the session saves again", async () => {
+    const workspace = await temporaryDirectory("omp-blob-revive-ws-");
+    const storage = await temporaryDirectory("omp-blob-revive-store-");
+    const sessionId = "blob-revived-session";
+    const sessionHash = checkpointNamespace(sessionId);
+    const store = new BlobStore(storage);
+
+    const historyDir = join(storage, "history");
+    await mkdir(historyDir, { recursive: true });
+    const tombstoneFile = join(historyDir, `${sessionHash}.expired.json`);
+    await writeFile(
+      tombstoneFile,
+      JSON.stringify({
+        expired: true,
+        sessionHash,
+        expiredAt: new Date().toISOString(),
+        reason: "storage_cap",
+      }),
+    );
+
+    const history = new BlobHistoryStore(sessionId, workspace, store);
+    // A live owner saving new history supersedes the earlier expiration.
+    await history.save({
+      checkpoints: [
+        {
+          kind: "session",
+          reason: "resumed_checkpoint_unavailable",
+          parentLeafId: null,
+          leafId: null,
+        },
+      ],
+      currentIndex: 0,
+    });
+    await expect(stat(tombstoneFile)).rejects.toThrow();
+
+    // The next resume loads the new history instead of reporting expired.
+    await expect(history.load(reader())).resolves.toEqual({
+      status: "loaded",
+      state: {
+        checkpoints: [
+          {
+            kind: "session",
+            reason: "resumed_checkpoint_unavailable",
+            parentLeafId: null,
+            leafId: null,
+          },
+        ],
+        currentIndex: 0,
+      },
+    });
+
     await store.shutdown();
   });
 

--- a/test/history-expiration.test.ts
+++ b/test/history-expiration.test.ts
@@ -304,4 +304,280 @@ describe("expireGitSessionHistories", () => {
       reason: "storage_cap",
     });
   });
+
+  it("preserves sessions with a fresh cross-process heartbeat marker", async () => {
+    const gitDir = await temporaryDirectory("git-expire-heartbeat-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "heartbeat-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+    // A foreign process holds this session open and beats the marker.
+    const markerPath = join(gitDir, "omp-undo-redo", "history", `.active.${hash}`);
+    await writeFile(markerPath, "");
+
+    const deletedRefCommands: string[] = [];
+    const dummyGit: GitRunner = async (args, options) => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: `refs/omp-undo-redo/history/${hash}/chk1/before\0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (args[0] === "update-ref" && args[1] === "--stdin") {
+        deletedRefCommands.push(options?.stdin ?? "");
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    expect((await stat(historyFile)).isFile()).toBe(true);
+    await expect(stat(tombstonePath(repository, sessionId))).rejects.toThrow();
+    expect(deletedRefCommands).toEqual([]);
+  });
+
+  it("expires sessions once their cross-process heartbeat goes stale", async () => {
+    const gitDir = await temporaryDirectory("git-expire-beat-stale-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "stale-heartbeat-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: oldDate,
+      }),
+    );
+    const markerPath = join(gitDir, "omp-undo-redo", "history", `.active.${hash}`);
+    await writeFile(markerPath, "");
+    const stale = (Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000;
+    await utimes(markerPath, stale, stale);
+
+    const dummyGit: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") return { stdout: "", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    await expect(stat(historyFile)).rejects.toThrow();
+    const tombstone = JSON.parse(await readFile(tombstonePath(repository, sessionId), "utf8"));
+    expect(tombstone.reason).toBe("age");
+    // The sweep prunes the marker whose owner stopped beating.
+    await expect(stat(markerPath)).rejects.toThrow();
+  });
+
+  it("keeps original git checkpoint coordinates on disk when refs are missing at resume", async () => {
+    const gitDir = await temporaryDirectory("git-resume-nopersist-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "nopersist-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const refPrefix = `refs/omp-undo-redo/history/${hash}/`;
+    const beforeHash = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+    const afterHash = "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0a1";
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [
+          {
+            kind: "git",
+            repository,
+            beforeHash,
+            afterHash,
+            beforeRef: `${refPrefix}chk1/before`,
+            afterRef: `${refPrefix}chk1/after`,
+            parentLeafId: "prompt",
+            leafId: "response",
+          },
+        ],
+        currentIndex: 0,
+      }),
+    );
+
+    // Refs are gone (concurrent expiration deleted them mid-resume).
+    const dummyGit: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") return { stdout: "", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const dummyReader = {
+      getLeafId: () => "response",
+      getBranch: () => [
+        { id: "prompt", parentId: null, type: "message", message: { role: "user" } },
+        { id: "response", parentId: "prompt", type: "message", message: { role: "assistant" } },
+      ],
+      getEntry: (id: string) =>
+        id === "prompt" || id === "response"
+          ? { id, parentId: id === "prompt" ? null : "prompt", type: "message" }
+          : undefined,
+    };
+
+    const { SessionHistoryStore } = await import("../src/core/history-store.js");
+    const store = new SessionHistoryStore(sessionId, repository, dummyGit);
+
+    const result = await store.load(dummyReader);
+    expect(result.status).toBe("loaded");
+    if (result.status !== "loaded") return;
+    // Runtime view degrades gracefully to navigation-only checkpoints...
+    expect(result.state.checkpoints).toEqual([
+      {
+        kind: "session",
+        reason: "resumed_checkpoint_unavailable",
+        parentLeafId: "prompt",
+        leafId: "response",
+      },
+    ]);
+
+    // ...but the stored document keeps the original coordinates so the loss
+    // never becomes durable through load itself.
+    const raw = JSON.parse(await readFile(historyFile, "utf8"));
+    expect(raw.schemaVersion).toBe(2);
+    expect(typeof raw.lastAccessedAt).toBe("string");
+    expect(raw.checkpoints).toEqual([
+      {
+        kind: "git",
+        repository,
+        beforeHash,
+        afterHash,
+        beforeRef: `${refPrefix}chk1/before`,
+        afterRef: `${refPrefix}chk1/after`,
+        parentLeafId: "prompt",
+        leafId: "response",
+      },
+    ]);
+
+    // Loading also left a cross-process heartbeat for this session.
+    const markerPath = join(gitDir, "omp-undo-redo", "history", `.active.${hash}`);
+    expect((await stat(markerPath)).isFile()).toBe(true);
+  });
+
+  it("removes a history JSON that coexists with its tombstone (residue cleanup)", async () => {
+    const gitDir = await temporaryDirectory("git-residue-cleanup-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "residue-session";
+    const hash = sessionHash(sessionId);
+    const historyFile = historyPath(repository, sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    // A concurrent load rewrote the file after the sweep completed: fresh
+    // timestamp, no owner. The tombstone must stay authoritative regardless
+    // of the JSON's age.
+    await writeFile(
+      historyFile,
+      JSON.stringify({
+        schemaVersion: 2,
+        sessionHash: hash,
+        repository,
+        checkpoints: [],
+        currentIndex: -1,
+        lastAccessedAt: new Date().toISOString(),
+      }),
+    );
+    const tombstoneFile = tombstonePath(repository, sessionId);
+    await writeFile(
+      tombstoneFile,
+      JSON.stringify({
+        expired: true,
+        sessionHash: hash,
+        expiredAt: new Date().toISOString(),
+        reason: "age",
+      }),
+    );
+
+    const dummyGit: GitRunner = async () => ({ stdout: "", stderr: "", code: 0 });
+    await expireGitSessionHistories(repository, dummyGit, 30, new Set());
+
+    await expect(stat(historyFile)).rejects.toThrow();
+    expect((await stat(tombstoneFile)).isFile()).toBe(true);
+  });
+
+  it("clears a superseded tombstone when the session saves again", async () => {
+    const gitDir = await temporaryDirectory("git-tombstone-clear-");
+    const repository: GitRepository = { worktree: gitDir, gitDir, commonDir: gitDir };
+    const sessionId = "revived-session";
+    const hash = sessionHash(sessionId);
+
+    await mkdir(join(gitDir, "omp-undo-redo", "history"), { recursive: true });
+    const tombstoneFile = tombstonePath(repository, sessionId);
+    await writeFile(
+      tombstoneFile,
+      JSON.stringify({
+        expired: true,
+        sessionHash: hash,
+        expiredAt: new Date().toISOString(),
+        reason: "age",
+      }),
+    );
+
+    const dummyGit: GitRunner = async (args) => {
+      if (args[0] === "for-each-ref") return { stdout: "", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const { SessionHistoryStore } = await import("../src/core/history-store.js");
+    const store = new SessionHistoryStore(sessionId, repository, dummyGit);
+
+    // A live owner saving new history supersedes the earlier expiration.
+    await store.save({
+      checkpoints: [
+        {
+          kind: "session",
+          reason: "resumed_checkpoint_unavailable",
+          parentLeafId: null,
+          leafId: null,
+        },
+      ],
+      currentIndex: 0,
+    });
+    await expect(stat(tombstoneFile)).rejects.toThrow();
+
+    // The next resume loads the new history instead of reporting expired.
+    const dummyReader = {
+      getLeafId: () => null,
+      getBranch: () => [],
+      getEntry: () => undefined,
+    };
+    await expect(store.load(dummyReader)).resolves.toEqual({
+      status: "loaded",
+      state: {
+        checkpoints: [
+          {
+            kind: "session",
+            reason: "resumed_checkpoint_unavailable",
+            parentLeafId: null,
+            leafId: null,
+          },
+        ],
+        currentIndex: 0,
+      },
+    });
+  });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -852,6 +852,16 @@ describe("resumed session history", () => {
       const content = JSON.parse(await readFile(hPath, "utf8"));
       content.lastAccessedAt = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
       await writeFile(hPath, JSON.stringify(content));
+      // The turn saves left a fresh cross-process heartbeat marker; drop it
+      // so no live owner is implied and the dormant session is sweepable.
+      const { activeHeartbeatPath } = await import("../src/core/history-liveness.js");
+      await rm(
+        activeHeartbeatPath(
+          join(repo.commonDir, "omp-undo-redo", "history"),
+          checkpointNamespace(sessionId1),
+        ),
+        { force: true },
+      );
 
       // 3. Start session 2 to trigger background expiration of dormant session 1
       const secondApi = new FakeExtensionApi();


### PR DESCRIPTION
## Summary

Retention sweeps filtered expiration candidates only against the local process's in-memory active-session set, while history files live in directories shared by every worktree/process of a repo (commonDir) or blob-store root. A sweeper in one process could delete refs and tombstone a session another process was actively resuming; the resume then re-persisted the degraded state, durably converting file-restorable checkpoints into navigation-only rows.

## Changes

- Never persist runtime-downgraded checkpoints: load() rewrites stored history with the original coordinates + fresh lastAccessedAt only (src/core/history-store.ts, src/core/blob-history-store.ts)
- Cross-process liveness markers: .active.<sessionHash> heartbeats (24h TTL) touched on every load/save, honored by both sweepers and tombstone pruning, with pre-deletion re-checks (new src/core/history-liveness.ts)
- 10-minute unref'd interval re-asserts liveness for locally active sessions so idle-open sessions stay protected (src/index.ts)
- Tombstones are authoritative until superseded: save() clears the session's own marker (post-expiry sessions regain undo on their next turn); sweeps remove JSON residue under standing tombstones
- Storage-cap eviction keeps its hard oldest-first guarantee; liveness enforced purely by heartbeats
- README/CHANGELOG parity; version 1.5.4

## Verification

- npm run verify: format:check, lint, typecheck, 170 tests passed (15 files), build output parity, package smoke, pack dry-run