### PR TITLE
fix: harden blob-store lock and lease protocol against path aliasing and stale deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@baylarsadigov/omp-undo-redo` are recorded here.
 
+## [1.5.6] - 2026-08-27
+
+### Fixed
+
+- **Blob-store lock & lease protocol hardening (scope canonicalization & liveness heartbeats):**
+  - **Textual path aliasing / split-brain prevention:** `BlobStore`, `StoreLocks`, `StoreLiveness`, `captureSnapshot`, `applySnapshot`, and `invalidateCache` now canonicalize store and workspace roots via native `realpath` (`canonicalPath`/`canonicalPathSync` in `src/core/blob-store/fs.ts`), ensuring symlinks, Windows 8.3 short paths, casing differences, and relative path spellings hash to identical lock keys (`src/core/blob-store/locks.ts`, `src/core/blob-store/index.ts`, `src/core/blob-store/liveness.ts`).
+  - **Lock heartbeats & PID recycling protection:** lock holders write `{ pid, hostname, ownerId, startedAt }` atomically via temp file and maintain a 5s heartbeat (`utimes`). Same-host contenders reap dead processes instantly on `ESRCH` and reclaim hung/recycled PIDs when heartbeat is stale (>30s) (`src/core/blob-store/locks.ts`).
+  - **Cross-host split-brain protection:** foreign-host locks are never reaped on short heartbeats, preventing clock-skew lock theft on shared network mounts (NFS/SMB); an abandoned foreign lock is reclaimed only after a conservative 24h fallback window (`src/core/blob-store/locks.ts`).
+  - **Release-after-reap fencing:** lock release closure verifies `owner.json` still matches `ownerId` before deleting, ensuring a stalled holder that wakes up after being reaped never deletes a new holder's active lock (`src/core/blob-store/locks.ts`).
+  - **Lease liveness refresh:** repeat `publishLease()` calls refresh lease `mtime` via `utimes`, keeping long-running active sessions fresh (`src/core/blob-store/liveness.ts`).
+
 ## [1.5.5] - 2026-08-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baylarsadigov/omp-undo-redo",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "MIT",
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "16.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baylarsadigov/omp-undo-redo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Undo and redo session navigation for Pi and Oh My Pi",
   "license": "MIT",
   "keywords": [

--- a/src/core/blob-store/fs.ts
+++ b/src/core/blob-store/fs.ts
@@ -1,7 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createReadStream, realpath as realpathCb, realpathSync } from "node:fs";
 import { chmod, mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const realpathNative = promisify(realpathCb.native);
 
 /** Filesystem, hashing, and path/id-guard primitives shared by the blob
  *  store's internal modules. Everything here is stateless. */
@@ -92,4 +95,44 @@ export function depth(value: string): number {
     if (value.charCodeAt(index) === 47) count++; // "/"
   }
   return count;
+}
+
+export function canonicalPathSync(path: string): string {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    let current = resolve(path);
+    const suffix: string[] = [];
+    while (true) {
+      try {
+        const canonical = realpathSync.native(current);
+        return suffix.length ? join(canonical, ...suffix.reverse()) : canonical;
+      } catch {
+        const parent = dirname(current);
+        if (parent === current) return resolve(path);
+        suffix.push(basename(current));
+        current = parent;
+      }
+    }
+  }
+}
+
+export async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpathNative(path);
+  } catch {
+    let current = resolve(path);
+    const suffix: string[] = [];
+    while (true) {
+      try {
+        const canonical = await realpathNative(current);
+        return suffix.length ? join(canonical, ...suffix.reverse()) : canonical;
+      } catch {
+        const parent = dirname(current);
+        if (parent === current) return resolve(path);
+        suffix.push(basename(current));
+        current = parent;
+      }
+    }
+  }
 }

--- a/src/core/blob-store/index.ts
+++ b/src/core/blob-store/index.ts
@@ -1,8 +1,18 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
-import { atomicWrite, blobPathFor, exists, isHash, safeId, sha256, treePathFor } from "./fs.js";
+import {
+  atomicWrite,
+  blobPathFor,
+  canonicalPath,
+  canonicalPathSync,
+  exists,
+  isHash,
+  safeId,
+  sha256,
+  treePathFor,
+} from "./fs.js";
 import {
   canonicalManifest,
   manifestFileContent,
@@ -33,12 +43,15 @@ export type { BlobApplyResult, SnapshotPhase, TreeEntry, TreeManifest } from "./
 export { DEFAULT_BLOB_IGNORES } from "./types.js";
 
 export function blobStoreRootDirectory(): string {
-  if (process.env.OMP_UNDO_REDO_BLOB_DIR) return resolve(process.env.OMP_UNDO_REDO_BLOB_DIR);
+  if (process.env.OMP_UNDO_REDO_BLOB_DIR) {
+    return canonicalPathSync(process.env.OMP_UNDO_REDO_BLOB_DIR);
+  }
   if (process.env.OMP_UNDO_REDO_RUNTIME_DIR) {
     const runtime = resolve(process.env.OMP_UNDO_REDO_RUNTIME_DIR);
-    return basenameIsRuntime(runtime) ? dirname(runtime) : runtime;
+    const dir = basenameIsRuntime(runtime) ? dirname(runtime) : runtime;
+    return canonicalPathSync(dir);
   }
-  return resolve(join(homedir(), ".omp", "omp-undo-redo"));
+  return canonicalPathSync(join(homedir(), ".omp", "omp-undo-redo"));
 }
 
 /** The literal "/runtime" catches env-var paths written with forward slashes
@@ -86,7 +99,7 @@ export class BlobStore {
       walkConcurrency?: number;
     } = {},
   ) {
-    this.rootDirectory = resolve(rootDirectory);
+    this.rootDirectory = canonicalPathSync(rootDirectory);
     const clock = options.clock ?? (() => new Date());
     this.clock = clock;
     this.locks = new StoreLocks(this.rootDirectory, this.ownerId);
@@ -107,7 +120,8 @@ export class BlobStore {
     this.mutator = new WorkspaceMutator({
       storeRoot: this.rootDirectory,
       clock,
-      invalidateCache: (workspaceRoot) => this.workspaceCaches.delete(workspaceRoot),
+      invalidateCache: (workspaceRoot) =>
+        this.workspaceCaches.delete(canonicalPathSync(workspaceRoot)),
     });
     this.janitor = new StoreJanitor({
       rootDirectory: this.rootDirectory,
@@ -196,7 +210,7 @@ export class BlobStore {
     if (!isHash(sessionHash) || !safeId(checkpointId)) return { reason: "blob_capture_failed" };
     let canonicalRoot: string;
     try {
-      canonicalRoot = await realpath(workspaceRoot);
+      canonicalRoot = await canonicalPath(workspaceRoot);
       if (!(await lstat(canonicalRoot)).isDirectory()) return { reason: "workspace_unresolvable" };
     } catch {
       return { reason: "workspace_unresolvable" };
@@ -333,7 +347,7 @@ export class BlobStore {
   ): Promise<BlobApplyResult> {
     let root: string;
     try {
-      root = await realpath(workspaceRoot);
+      root = await canonicalPath(workspaceRoot);
     } catch {
       return { status: "failed" };
     }

--- a/src/core/blob-store/liveness.ts
+++ b/src/core/blob-store/liveness.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join } from "node:path";
 import type { Dirent } from "node:fs";
-import { atomicWrite } from "./fs.js";
+import { atomicWrite, canonicalPathSync } from "./fs.js";
 
 /** Captures walk their workspace outside the store lock and write blobs that
  *  no ref references until the walk's publish step. A concurrent GC must not
@@ -16,8 +16,10 @@ const CAPTURE_MARKER_STALE_MS = 30_000;
 
 /** Cross-process liveness for the store: the lease that proves this owner is
  *  alive (used to reap a dead owner's active refs) and the capture markers
- *  that defer GC sweeps while captures are in flight. */
-
+ *  that defer GC sweeps while captures are in flight.
+ *
+ *  Note on foreign leases: leases from foreign hosts on shared filesystems
+ *  are conservatively reaped after 24h of inactivity (no snapshots/sweeps). */
 export class StoreLiveness {
   private readonly rootDirectory: string;
   private readonly ownerId: string;
@@ -25,7 +27,7 @@ export class StoreLiveness {
   private leasePublished = false;
 
   constructor(rootDirectory: string, ownerId: string, clock: () => Date) {
-    this.rootDirectory = rootDirectory;
+    this.rootDirectory = canonicalPathSync(rootDirectory);
     this.ownerId = ownerId;
     this.clock = clock;
   }
@@ -35,9 +37,14 @@ export class StoreLiveness {
   }
 
   async publishLease(): Promise<void> {
-    if (this.leasePublished) return;
+    const leasePath = join(this.rootDirectory, "leases", `${this.ownerId}.json`);
+    if (this.leasePublished) {
+      const now = new Date();
+      await utimes(leasePath, now, now).catch(() => undefined);
+      return;
+    }
     await atomicWrite(
-      join(this.rootDirectory, "leases", `${this.ownerId}.json`),
+      leasePath,
       JSON.stringify({
         ownerId: this.ownerId,
         pid: process.pid,
@@ -171,8 +178,6 @@ export class StoreLiveness {
                 } catch (e) {
                   if ((e as NodeJS.ErrnoException).code !== "ESRCH") continue;
                 }
-              } else {
-                continue;
               }
               await rm(join(leasesDir, entry.name), { force: true }).catch(() => undefined);
             }

--- a/src/core/blob-store/locks.ts
+++ b/src/core/blob-store/locks.ts
@@ -1,8 +1,13 @@
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { sha256 } from "./fs.js";
+import { canonicalPath, canonicalPathSync, sha256 } from "./fs.js";
+
+const LOCK_HEARTBEAT_MS = 5_000;
+const LOCK_LOCAL_STALE_MS = 30_000;
+const LOCK_FOREIGN_STALE_MS = 24 * 60 * 60 * 1000;
 
 /** Mutual exclusion for the blob store. Two layers that must always be
  *  taken together:
@@ -20,7 +25,7 @@ export class StoreLocks {
   private readonly locks = new Map<string, Promise<void>>();
 
   constructor(rootDirectory: string, ownerId: string) {
-    this.rootDirectory = rootDirectory;
+    this.rootDirectory = canonicalPathSync(rootDirectory);
     this.ownerId = ownerId;
   }
 
@@ -32,17 +37,42 @@ export class StoreLocks {
       try {
         await mkdir(lockPath, { mode: 0o700 });
         try {
-          await writeFile(
-            join(lockPath, "owner.json"),
-            JSON.stringify({ pid: process.pid, hostname: hostname(), ownerId: this.ownerId }),
-            { mode: 0o600 },
-          );
+          const content = JSON.stringify({
+            pid: process.pid,
+            hostname: hostname(),
+            ownerId: this.ownerId,
+            startedAt: new Date().toISOString(),
+          });
+          const tmpPath = join(lockPath, `owner.${randomUUID()}.tmp`);
+          await writeFile(tmpPath, content, { mode: 0o600 });
+          await rename(tmpPath, join(lockPath, "owner.json"));
         } catch (error) {
           await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
           throw error;
         }
+        const beat = async (): Promise<void> => {
+          try {
+            const now = new Date();
+            await utimes(lockPath, now, now);
+          } catch {
+            // Lock released or unavailable
+          }
+        };
+        const interval = setInterval(() => void beat(), LOCK_HEARTBEAT_MS);
+        interval.unref();
+
         return async () => {
-          await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+          clearInterval(interval);
+          try {
+            const current = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as {
+              ownerId?: string;
+            };
+            if (current.ownerId === this.ownerId) {
+              await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+            }
+          } catch {
+            // Lock already reaped, removed, or unreadable — never delete another holder's lock
+          }
         };
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
@@ -51,24 +81,58 @@ export class StoreLocks {
           const owner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as {
             pid?: number;
             hostname?: string;
+            ownerId?: string;
+            startedAt?: string;
           };
+          const metadata = await stat(lockPath);
           if (owner.hostname === hostname() && typeof owner.pid === "number") {
             try {
               process.kill(owner.pid, 0);
             } catch (probeError) {
               if ((probeError as NodeJS.ErrnoException).code === "ESRCH") {
-                await rm(lockPath, { recursive: true, force: true });
+                await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+                continue;
+              }
+            }
+            // Same host: heartbeat staleness catches recycled PIDs and hung processes safely
+            if (Date.now() - metadata.mtimeMs > LOCK_LOCAL_STALE_MS) {
+              await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+              continue;
+            }
+          } else {
+            // Foreign host / unprobeable: do not steal locks on short heartbeat (clock skew risk).
+            // Only reap after conservative 24h fallback window to prevent permanent lockout.
+            // Note: assumes foreign host wall-clock skew is within 24h.
+            if (Date.now() - metadata.mtimeMs > LOCK_FOREIGN_STALE_MS) {
+              let recent = false;
+              if (owner.startedAt) {
+                const startedMs = Date.parse(owner.startedAt);
+                if (!Number.isNaN(startedMs) && Date.now() - startedMs < LOCK_FOREIGN_STALE_MS) {
+                  recent = true;
+                }
+              }
+              if (!recent) {
+                await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
                 continue;
               }
             }
           }
         } catch {
-          // A process can crash between mkdir and owner publication. Reap only an old,
-          // ownerless lock; a live publisher gets a generous completion window.
+          // A process can crash between mkdir and owner publication (owner.json missing or partial),
+          // or owner.json exists but is unparseable / permission-denied.
           try {
             const metadata = await stat(lockPath);
-            if (Date.now() - metadata.mtimeMs > 30_000) {
-              await rm(lockPath, { recursive: true, force: true });
+            let timeoutThreshold = LOCK_LOCAL_STALE_MS;
+            try {
+              const raw = await readFile(join(lockPath, "owner.json"), "utf8");
+              if (raw.includes(`"hostname":"`) && !raw.includes(`"hostname":"${hostname()}"`)) {
+                timeoutThreshold = LOCK_FOREIGN_STALE_MS;
+              }
+            } catch {
+              // Missing or unreadable — treat as local crash
+            }
+            if (Date.now() - metadata.mtimeMs > timeoutThreshold) {
+              await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
               continue;
             }
           } catch {
@@ -117,8 +181,9 @@ export class StoreLocks {
    *  blocks another workspace — the store lock is reserved for ref/manifest
    *  publication and GC, which the whole store must agree on. */
   async withWorkspaceMutex<T>(root: string, operation: () => Promise<T>): Promise<T> {
-    return this.withWorkspaceLock(root, async () => {
-      const release = await this.acquireFilesystemLock(`workspace:${root}`);
+    const canonicalRoot = await canonicalPath(root);
+    return this.withWorkspaceLock(canonicalRoot, async () => {
+      const release = await this.acquireFilesystemLock(`workspace:${canonicalRoot}`);
       try {
         return await operation();
       } finally {

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -31,6 +31,20 @@ function sessionHash(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function withResolvers<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
@@ -770,8 +784,8 @@ describe("non-Git blob store", () => {
     const locks1 = new StoreLocks(storage, "owner-1");
     const locks2 = new StoreLocks(aliasedStorage, "owner-2");
 
-    const firstEntered = Promise.withResolvers<void>();
-    const releaseFirst = Promise.withResolvers<void>();
+    const firstEntered = withResolvers<void>();
+    const releaseFirst = withResolvers<void>();
 
     const op1 = locks1.withWorkspaceMutex(workspace, async () => {
       firstEntered.resolve();
@@ -934,8 +948,8 @@ describe("non-Git blob store", () => {
 
     const locks1 = new StoreLocks(storage, "owner-1");
 
-    const holder1Entered = Promise.withResolvers<void>();
-    const finishHolder1 = Promise.withResolvers<void>();
+    const holder1Entered = withResolvers<void>();
+    const finishHolder1 = withResolvers<void>();
 
     // Holder 1 acquires lock
     const op1 = locks1.withWorkspaceMutex(workspace, async () => {

--- a/test/blob-store.test.ts
+++ b/test/blob-store.test.ts
@@ -17,7 +17,8 @@ import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { BlobStore } from "../src/core/blob-store/index.js";
-
+import { StoreLocks } from "../src/core/blob-store/locks.js";
+import { canonicalPath, sha256 } from "../src/core/blob-store/fs.js";
 const temporaryDirectories: string[] = [];
 
 async function temporaryDirectory(prefix: string): Promise<string> {
@@ -741,5 +742,236 @@ describe("non-Git blob store", () => {
     expect(released).toBe(true);
     expect(await store.hasHistoryRef(session, checkpoint, "before")).toBe(false);
     await store.shutdown();
+  });
+
+  it("canonicalizes store and workspace roots to avoid lock key split-brain on aliased paths", async () => {
+    const workspace = await temporaryDirectory("omp-blob-alias-workspace-");
+    const storage = await temporaryDirectory("omp-blob-alias-storage-");
+
+    // Construct true symlink aliases for workspace and storage
+    const symlinkParent = await temporaryDirectory("omp-blob-symlink-parent-");
+    const symlinkWorkspace = join(symlinkParent, "ws-link");
+    const symlinkStorage = join(symlinkParent, "store-link");
+
+    try {
+      await symlink(workspace, symlinkWorkspace, "junction");
+      await symlink(storage, symlinkStorage, "junction");
+    } catch {
+      // If symlink creation not permitted on environment, fallback to casing
+    }
+
+    const aliasedWorkspace = await stat(symlinkWorkspace)
+      .then(() => symlinkWorkspace)
+      .catch(() => workspace.toUpperCase());
+    const aliasedStorage = await stat(symlinkStorage)
+      .then(() => symlinkStorage)
+      .catch(() => storage.toUpperCase());
+
+    const locks1 = new StoreLocks(storage, "owner-1");
+    const locks2 = new StoreLocks(aliasedStorage, "owner-2");
+
+    const firstEntered = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+
+    const op1 = locks1.withWorkspaceMutex(workspace, async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      return "first";
+    });
+
+    await firstEntered.promise;
+
+    // Start op2 while op1 holds the lock — op2 should block on the mutex
+    let op2Started = false;
+    const op2 = locks2.withWorkspaceMutex(aliasedWorkspace, async () => {
+      op2Started = true;
+      return "second";
+    });
+
+    // Give microtasks a turn to ensure op2 tried to acquire
+    await Promise.resolve();
+    expect(op2Started).toBe(false);
+
+    // Release first lock
+    releaseFirst.resolve();
+
+    const [res1, res2] = await Promise.all([op1, op2]);
+    expect(res1).toBe("first");
+    expect(res2).toBe("second");
+  });
+  it("reaps same-host locks with dead heartbeats (recycled PID protection)", async () => {
+    const workspace = await temporaryDirectory("omp-blob-stale-local-workspace-");
+    const storage = await temporaryDirectory("omp-blob-stale-local-storage-");
+    const canonicalWorkspace = await canonicalPath(workspace);
+    const lockKey = sha256(`workspace:${canonicalWorkspace}`);
+    const lockPath = join(storage, "locks", `${lockKey}.lock`);
+
+    await mkdir(lockPath, { recursive: true });
+    // Point to current pid (which is alive) but with a dead heartbeat (>30s)
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        hostname: hostname(),
+        pid: process.pid,
+        ownerId: "stale-same-host-owner",
+        startedAt: new Date(Date.now() - 40_000).toISOString(),
+      }),
+    );
+
+    const oldTime = new Date(Date.now() - 40_000);
+    await utimes(lockPath, oldTime, oldTime);
+
+    const locks = new StoreLocks(storage, "local-owner");
+    const result = await locks.withWorkspaceMutex(workspace, async () => "acquired");
+    expect(result).toBe("acquired");
+  });
+
+  it("reaps abandoned foreign-host locks after 24h fallback window", async () => {
+    const workspace = await temporaryDirectory("omp-blob-stale-foreign-workspace-");
+    const storage = await temporaryDirectory("omp-blob-stale-foreign-storage-");
+    const canonicalWorkspace = await canonicalPath(workspace);
+    const lockKey = sha256(`workspace:${canonicalWorkspace}`);
+    const lockPath = join(storage, "locks", `${lockKey}.lock`);
+
+    await mkdir(lockPath, { recursive: true });
+    const dayAndHalfAgo = Date.now() - 36 * 60 * 60 * 1000;
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        hostname: "dead-foreign-host",
+        pid: 999999,
+        ownerId: "dead-foreign-owner",
+        startedAt: new Date(dayAndHalfAgo).toISOString(),
+      }),
+    );
+
+    const oldTime = new Date(dayAndHalfAgo);
+    await utimes(lockPath, oldTime, oldTime);
+
+    const locks = new StoreLocks(storage, "local-owner");
+    const result = await locks.withWorkspaceMutex(workspace, async () => "acquired");
+    expect(result).toBe("acquired");
+  });
+
+  it("does not steal fresh foreign-host locks and rejects on timeout", async () => {
+    const workspace = await temporaryDirectory("omp-blob-fresh-foreign-workspace-");
+    const storage = await temporaryDirectory("omp-blob-fresh-foreign-storage-");
+    const canonicalWorkspace = await canonicalPath(workspace);
+    const lockKey = sha256(`workspace:${canonicalWorkspace}`);
+    const lockPath = join(storage, "locks", `${lockKey}.lock`);
+
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        hostname: "active-foreign-host",
+        pid: 999999,
+        ownerId: "active-foreign-owner",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    const locks = new StoreLocks(storage, "local-contender");
+    await expect(
+      locks.withWorkspaceMutex(workspace, async () => "should-not-acquire"),
+    ).rejects.toThrow("blob store lock timeout");
+  }, 15_000);
+
+  it("writes startedAt and heartbeats active locks", async () => {
+    const workspace = await temporaryDirectory("omp-blob-heartbeat-workspace-");
+    const storage = await temporaryDirectory("omp-blob-heartbeat-storage-");
+    const canonicalWorkspace = await canonicalPath(workspace);
+    const lockKey = sha256(`workspace:${canonicalWorkspace}`);
+    const lockPath = join(storage, "locks", `${lockKey}.lock`);
+
+    const locks = new StoreLocks(storage, "active-owner");
+    await locks.withWorkspaceMutex(workspace, async () => {
+      const content = await readFile(join(lockPath, "owner.json"), "utf8");
+      const owner = JSON.parse(content) as { startedAt?: string; pid?: number };
+      expect(typeof owner.startedAt).toBe("string");
+      expect(Number.isNaN(Date.parse(owner.startedAt!))).toBe(false);
+      expect(owner.pid).toBe(process.pid);
+    });
+  });
+
+  it("reaps foreign leases older than 24h during stale lease sweep", async () => {
+    const storage = await temporaryDirectory("omp-blob-foreign-lease-storage-");
+    const store = new BlobStore(storage);
+    const leasesDir = join(storage, "leases");
+    await mkdir(leasesDir, { recursive: true });
+
+    const foreignOwner = randomUUID();
+    const dayAndHalfAgo = Date.now() - 36 * 60 * 60 * 1000;
+    const leasePath = join(leasesDir, `${foreignOwner}.json`);
+    await writeFile(
+      leasePath,
+      JSON.stringify({
+        ownerId: foreignOwner,
+        pid: 999999,
+        hostname: "dead-foreign-host",
+        startedAt: new Date(dayAndHalfAgo).toISOString(),
+      }),
+    );
+
+    const oldTime = new Date(dayAndHalfAgo);
+    await utimes(leasePath, oldTime, oldTime);
+
+    await store.garbageCollect();
+    expect(
+      await stat(leasePath)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(false);
+    await store.shutdown();
+  });
+
+  it("fences lock release so a stalled holder never deletes a new holder's lock", async () => {
+    const workspace = await temporaryDirectory("omp-blob-fencing-workspace-");
+    const storage = await temporaryDirectory("omp-blob-fencing-storage-");
+    const canonicalWorkspace = await canonicalPath(workspace);
+    const lockKey = sha256(`workspace:${canonicalWorkspace}`);
+    const lockPath = join(storage, "locks", `${lockKey}.lock`);
+
+    const locks1 = new StoreLocks(storage, "owner-1");
+
+    const holder1Entered = Promise.withResolvers<void>();
+    const finishHolder1 = Promise.withResolvers<void>();
+
+    // Holder 1 acquires lock
+    const op1 = locks1.withWorkspaceMutex(workspace, async () => {
+      holder1Entered.resolve();
+      await finishHolder1.promise;
+    });
+
+    await holder1Entered.promise;
+
+    // Simulate lock being reaped / overwritten by Holder 2
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        hostname: hostname(),
+        pid: process.pid,
+        ownerId: "owner-2",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    // Holder 1 finishes and releases
+    finishHolder1.resolve();
+    await op1;
+
+    // Holder 2's lock must still exist on disk!
+    expect(
+      await stat(lockPath)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+    const content = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as {
+      ownerId?: string;
+    };
+    expect(content.ownerId).toBe("owner-2");
+
+    // Cleanup
+    await rm(lockPath, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
Hardens the blob-store mutual exclusion and liveness protocol against split-brain path aliasing, PID recycling deadlocks, and cross-host lock theft.

- **Scope binding & canonicalization:** Store and workspace roots are canonicalized via native `realpath` across `BlobStore`, `StoreLocks`, `StoreLiveness`, `captureSnapshot`, `applySnapshot`, and `invalidateCache`.
- **Lock heartbeats & PID recycling protection:** `owner.json` is published atomically and kept fresh with a 5s heartbeat (`utimes`). Same-host contenders reap dead processes on `ESRCH` or after a 30s stale heartbeat.
- **Foreign-host protection:** Foreign locks are not stolen on short heartbeats (protecting shared NFS/SMB mounts against clock skew); reaped only after a 24h fallback window.
- **Release fencing:** Release closure verifies `ownerId` before deleting `.lock` directories, preventing reaped/stalled processes from destroying active locks.
- **Lease liveness:** Repeat `publishLease()` calls refresh lease `mtime`.

## Verification
- `npm run verify` passed completely (Prettier, ESLint, TypeScript, Vitest 181 passed / 6 skipped, clean build, packaging smoke test, and dry pack).