### PR TITLE
ci: group dependabot updates for vitest and typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"


### PR DESCRIPTION
Groups Vitest and TypeScript ESLint updates so Dependabot bumps them together in single PRs instead of creating conflicting individual PRs.